### PR TITLE
Flattens data when fetch with .data()

### DIFF
--- a/.babelrc
+++ b/.babelrc
@@ -4,7 +4,7 @@
       "env",
       {
         "targets": {
-          "node": "6.14.0"
+          "node": "6.4.0"
         }
       }
     ]
@@ -14,6 +14,7 @@
     "es6": true
   },
   "plugins": [
-    "add-module-exports"
+    "add-module-exports",
+    "transform-es2017-object-entries"
   ]
 }

--- a/dist/browser/mock-cloud-firestore.js
+++ b/dist/browser/mock-cloud-firestore.js
@@ -363,8 +363,29 @@ function filterByCursor(data, prop, value, cursor) {
     return data[id][prop] >= value;
   });
 
-  for (const id of ids) {
-    filteredData[id] = data[id];
+  var _iteratorNormalCompletion = true;
+  var _didIteratorError = false;
+  var _iteratorError = undefined;
+
+  try {
+    for (var _iterator = ids[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+      const id = _step.value;
+
+      filteredData[id] = data[id];
+    }
+  } catch (err) {
+    _didIteratorError = true;
+    _iteratorError = err;
+  } finally {
+    try {
+      if (!_iteratorNormalCompletion && _iterator.return) {
+        _iterator.return();
+      }
+    } finally {
+      if (_didIteratorError) {
+        throw _iteratorError;
+      }
+    }
   }
 
   return filteredData;
@@ -382,8 +403,29 @@ function limit(data, threshold) {
   const filteredData = {};
   const ids = Object.keys(data).slice(0, threshold);
 
-  for (const id of ids) {
-    filteredData[id] = data[id];
+  var _iteratorNormalCompletion2 = true;
+  var _didIteratorError2 = false;
+  var _iteratorError2 = undefined;
+
+  try {
+    for (var _iterator2 = ids[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+      const id = _step2.value;
+
+      filteredData[id] = data[id];
+    }
+  } catch (err) {
+    _didIteratorError2 = true;
+    _iteratorError2 = err;
+  } finally {
+    try {
+      if (!_iteratorNormalCompletion2 && _iterator2.return) {
+        _iterator2.return();
+      }
+    } finally {
+      if (_didIteratorError2) {
+        throw _iteratorError2;
+      }
+    }
   }
 
   return filteredData;
@@ -421,8 +463,29 @@ function orderBy(data, key, order) {
     });
   }
 
-  for (const id of ids) {
-    filteredData[id] = data[id];
+  var _iteratorNormalCompletion3 = true;
+  var _didIteratorError3 = false;
+  var _iteratorError3 = undefined;
+
+  try {
+    for (var _iterator3 = ids[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+      const id = _step3.value;
+
+      filteredData[id] = data[id];
+    }
+  } catch (err) {
+    _didIteratorError3 = true;
+    _iteratorError3 = err;
+  } finally {
+    try {
+      if (!_iteratorNormalCompletion3 && _iterator3.return) {
+        _iterator3.return();
+      }
+    } finally {
+      if (_didIteratorError3) {
+        throw _iteratorError3;
+      }
+    }
   }
 
   return filteredData;
@@ -456,8 +519,29 @@ function where(data = {}, key, operator, value) {
     return data[id][key] > value;
   });
 
-  for (const id of ids) {
-    filteredData[id] = data[id];
+  var _iteratorNormalCompletion4 = true;
+  var _didIteratorError4 = false;
+  var _iteratorError4 = undefined;
+
+  try {
+    for (var _iterator4 = ids[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+      const id = _step4.value;
+
+      filteredData[id] = data[id];
+    }
+  } catch (err) {
+    _didIteratorError4 = true;
+    _iteratorError4 = err;
+  } finally {
+    try {
+      if (!_iteratorNormalCompletion4 && _iterator4.return) {
+        _iterator4.return();
+      }
+    } finally {
+      if (_didIteratorError4) {
+        throw _iteratorError4;
+      }
+    }
   }
 
   return filteredData;
@@ -467,14 +551,35 @@ function querySnapshot(data, collection) {
   const documentSnapshots = [];
 
   if (data && Object.prototype.hasOwnProperty.call(data, '__doc__')) {
-    for (const key of Object.keys(data.__doc__)) {
-      const documentRecord = data.__doc__[key];
+    var _iteratorNormalCompletion5 = true;
+    var _didIteratorError5 = false;
+    var _iteratorError5 = undefined;
 
-      if (!documentRecord.__isDeleted__) {
-        const documentReference = new _documentReference2.default(key, documentRecord, collection, collection.firestore);
-        const documentSnapshot = new _documentSnapshot2.default(key, documentRecord, documentReference);
+    try {
+      for (var _iterator5 = Object.keys(data.__doc__)[Symbol.iterator](), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
+        const key = _step5.value;
 
-        documentSnapshots.push(documentSnapshot);
+        const documentRecord = data.__doc__[key];
+
+        if (!documentRecord.__isDeleted__) {
+          const documentReference = new _documentReference2.default(key, documentRecord, collection, collection.firestore);
+          const documentSnapshot = new _documentSnapshot2.default(key, documentRecord, documentReference);
+
+          documentSnapshots.push(documentSnapshot);
+        }
+      }
+    } catch (err) {
+      _didIteratorError5 = true;
+      _iteratorError5 = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion5 && _iterator5.return) {
+          _iterator5.return();
+        }
+      } finally {
+        if (_didIteratorError5) {
+          throw _iteratorError5;
+        }
       }
     }
   }
@@ -564,23 +669,65 @@ class DocumentReference {
 
   set(data, option = {}) {
     if (!option.merge) {
-      for (const key of Object.keys(this._data)) {
-        if (key !== '__collection__') {
-          delete this._data[key];
+      var _iteratorNormalCompletion = true;
+      var _didIteratorError = false;
+      var _iteratorError = undefined;
+
+      try {
+        for (var _iterator = Object.keys(this._data)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+          const key = _step.value;
+
+          if (key !== '__collection__') {
+            delete this._data[key];
+          }
+        }
+      } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion && _iterator.return) {
+            _iterator.return();
+          }
+        } finally {
+          if (_didIteratorError) {
+            throw _iteratorError;
+          }
         }
       }
     }
 
     const parsedData = Object.assign({}, data);
 
-    for (const field of Object.keys(parsedData)) {
-      if (parsedData[field]) {
-        if (parsedData[field] instanceof DocumentReference) {
-          parsedData[field] = (0, _path.buildPathFromReference)(parsedData[field]);
-        }
+    var _iteratorNormalCompletion2 = true;
+    var _didIteratorError2 = false;
+    var _iteratorError2 = undefined;
 
-        if (typeof parsedData[field] === 'object' && Object.prototype.hasOwnProperty.call(parsedData[field], 'methodName') && parsedData[field].methodName === 'FieldValue.serverTimestamp') {
-          parsedData[field] = new Date();
+    try {
+      for (var _iterator2 = Object.keys(parsedData)[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+        const field = _step2.value;
+
+        if (parsedData[field]) {
+          if (parsedData[field] instanceof DocumentReference) {
+            parsedData[field] = (0, _path.buildPathFromReference)(parsedData[field]);
+          }
+
+          if (typeof parsedData[field] === 'object' && Object.prototype.hasOwnProperty.call(parsedData[field], 'methodName') && parsedData[field].methodName === 'FieldValue.serverTimestamp') {
+            parsedData[field] = new Date();
+          }
+        }
+      }
+    } catch (err) {
+      _didIteratorError2 = true;
+      _iteratorError2 = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion2 && _iterator2.return) {
+          _iterator2.return();
+        }
+      } finally {
+        if (_didIteratorError2) {
+          throw _iteratorError2;
         }
       }
     }
@@ -597,14 +744,35 @@ class DocumentReference {
 
     const parsedData = Object.assign({}, data);
 
-    for (const field of Object.keys(parsedData)) {
-      if (parsedData[field]) {
-        if (parsedData[field] instanceof DocumentReference) {
-          parsedData[field] = (0, _path.buildPathFromReference)(parsedData[field]);
-        }
+    var _iteratorNormalCompletion3 = true;
+    var _didIteratorError3 = false;
+    var _iteratorError3 = undefined;
 
-        if (typeof parsedData[field] === 'object' && Object.prototype.hasOwnProperty.call(parsedData[field], 'methodName') && parsedData[field].methodName === 'FieldValue.serverTimestamp') {
-          parsedData[field] = new Date();
+    try {
+      for (var _iterator3 = Object.keys(parsedData)[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+        const field = _step3.value;
+
+        if (parsedData[field]) {
+          if (parsedData[field] instanceof DocumentReference) {
+            parsedData[field] = (0, _path.buildPathFromReference)(parsedData[field]);
+          }
+
+          if (typeof parsedData[field] === 'object' && Object.prototype.hasOwnProperty.call(parsedData[field], 'methodName') && parsedData[field].methodName === 'FieldValue.serverTimestamp') {
+            parsedData[field] = new Date();
+          }
+        }
+      }
+    } catch (err) {
+      _didIteratorError3 = true;
+      _iteratorError3 = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion3 && _iterator3.return) {
+          _iterator3.return();
+        }
+      } finally {
+        if (_didIteratorError3) {
+          throw _iteratorError3;
         }
       }
     }
@@ -650,9 +818,16 @@ module.exports = exports['default'];
 "use strict";
 
 
-Object.defineProperty(exports, "__esModule", {
+(Object.defineProperty(exports, "__esModule", {
   value: true
-});
+}), function _objectEntries(obj) {
+  var entries = [];
+  var keys = Object.keys(obj);
+
+  for (var k = 0; k < keys.length; ++k) entries.push([keys[k], obj[keys[k]]]);
+
+  return entries;
+})
 class DocumentSnapshot {
   constructor(id, data, ref) {
     this._id = id;
@@ -685,12 +860,33 @@ class DocumentSnapshot {
     const keys = path.split('.');
     let data = this._getData();
 
-    for (const key of keys) {
-      if (Object.prototype.hasOwnProperty.call(data, key)) {
-        data = data[key];
-      } else {
-        data = undefined;
-        break;
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+      for (var _iterator = keys[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+        const key = _step.value;
+
+        if (Object.prototype.hasOwnProperty.call(data, key)) {
+          data = data[key];
+        } else {
+          data = undefined;
+          break;
+        }
+      }
+    } catch (err) {
+      _didIteratorError = true;
+      _iteratorError = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion && _iterator.return) {
+          _iterator.return();
+        }
+      } finally {
+        if (_didIteratorError) {
+          throw _iteratorError;
+        }
       }
     }
 
@@ -714,7 +910,7 @@ class DocumentSnapshot {
       return o;
     } else if (typeof o === 'object' && o !== null) {
       if (o.constructor === Object) {
-        return Object.entries(o).reduce((accumulator, [key, value]) => {
+        return _objectEntries(o).reduce((accumulator, [key, value]) => {
           if (key === '__collection__' || key === '__doc__') {
             return Object.assign({}, accumulator, this._traverseObject.call(this, value));
           } else {
@@ -945,8 +1141,29 @@ class QuerySnapshot {
   }
 
   forEach(callback) {
-    for (const data of this._data) {
-      callback(data);
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+      for (var _iterator = this._data[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+        const data = _step.value;
+
+        callback(data);
+      }
+    } catch (err) {
+      _didIteratorError = true;
+      _iteratorError = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion && _iterator.return) {
+          _iterator.return();
+        }
+      } finally {
+        if (_didIteratorError) {
+          throw _iteratorError;
+        }
+      }
     }
   }
 }
@@ -1091,16 +1308,79 @@ class WriteBatch {
   }
 
   commit() {
-    for (const write of this._writeBatch.set) {
-      write.ref.set(write.data, write.option);
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+      for (var _iterator = this._writeBatch.set[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+        const write = _step.value;
+
+        write.ref.set(write.data, write.option);
+      }
+    } catch (err) {
+      _didIteratorError = true;
+      _iteratorError = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion && _iterator.return) {
+          _iterator.return();
+        }
+      } finally {
+        if (_didIteratorError) {
+          throw _iteratorError;
+        }
+      }
     }
 
-    for (const write of this._writeBatch.update) {
-      write.ref.update(write.data);
+    var _iteratorNormalCompletion2 = true;
+    var _didIteratorError2 = false;
+    var _iteratorError2 = undefined;
+
+    try {
+      for (var _iterator2 = this._writeBatch.update[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+        const write = _step2.value;
+
+        write.ref.update(write.data);
+      }
+    } catch (err) {
+      _didIteratorError2 = true;
+      _iteratorError2 = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion2 && _iterator2.return) {
+          _iterator2.return();
+        }
+      } finally {
+        if (_didIteratorError2) {
+          throw _iteratorError2;
+        }
+      }
     }
 
-    for (const ref of this._writeBatch.delete) {
-      ref.delete();
+    var _iteratorNormalCompletion3 = true;
+    var _didIteratorError3 = false;
+    var _iteratorError3 = undefined;
+
+    try {
+      for (var _iterator3 = this._writeBatch.delete[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+        const ref = _step3.value;
+
+        ref.delete();
+      }
+    } catch (err) {
+      _didIteratorError3 = true;
+      _iteratorError3 = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion3 && _iterator3.return) {
+          _iterator3.return();
+        }
+      } finally {
+        if (_didIteratorError3) {
+          throw _iteratorError3;
+        }
+      }
     }
 
     return Promise.resolve();

--- a/dist/browser/mock-cloud-firestore.js
+++ b/dist/browser/mock-cloud-firestore.js
@@ -698,26 +698,42 @@ class DocumentSnapshot {
   }
 
   _getData() {
-    const data = Object.assign({}, this._data);
-
-    for (const key of Object.keys(data)) {
-      if (typeof data[key] === 'string' && data[key].startsWith('__ref__:')) {
-        data[key] = this._buildRefFromPath(this.ref.firestore, data[key].replace('__ref__:', ''));
-      } else if (data[key] instanceof Date) {
-        const date = data[key];
-
-        data[key] = {
-          toDate() {
-            return date;
-          }
-        };
-      }
-    }
+    const data = this._traverseObject(Object.assign({}, this._data));
 
     delete data.__isDirty__;
     delete data.__collection__;
 
     return data;
+  }
+
+  _traverseObject(o) {
+    if (typeof o === 'string') {
+      if (o.startsWith('__ref__:')) {
+        return this._buildRefFromPath(this.ref.firestore, o.replace('__ref__:', ''));
+      }
+      return o;
+    } else if (typeof o === 'object' && o !== null) {
+      if (o.constructor === Object) {
+        return Object.entries(o).reduce((accumulator, [key, value]) => {
+          if (key === '__collection__' || key === '__doc__') {
+            return Object.assign({}, accumulator, this._traverseObject.call(this, value));
+          } else {
+            return Object.assign({}, accumulator, {
+              [key]: this._traverseObject.call(this, value)
+            });
+          }
+        }, {});
+      } else if (o.constructor === Array) {
+        return o.map(this._traverseObject.bind(this));
+      } else if (o.constructor === Date) {
+        return {
+          toDate() {
+            return o;
+          }
+        };
+      }
+    }
+    return o;
   }
 
   _buildRefFromPath(db, path) {

--- a/dist/node/firebase/firestore/document-reference/index.js
+++ b/dist/node/firebase/firestore/document-reference/index.js
@@ -73,23 +73,65 @@ class DocumentReference {
 
   set(data, option = {}) {
     if (!option.merge) {
-      for (const key of Object.keys(this._data)) {
-        if (key !== '__collection__') {
-          delete this._data[key];
+      var _iteratorNormalCompletion = true;
+      var _didIteratorError = false;
+      var _iteratorError = undefined;
+
+      try {
+        for (var _iterator = Object.keys(this._data)[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+          const key = _step.value;
+
+          if (key !== '__collection__') {
+            delete this._data[key];
+          }
+        }
+      } catch (err) {
+        _didIteratorError = true;
+        _iteratorError = err;
+      } finally {
+        try {
+          if (!_iteratorNormalCompletion && _iterator.return) {
+            _iterator.return();
+          }
+        } finally {
+          if (_didIteratorError) {
+            throw _iteratorError;
+          }
         }
       }
     }
 
     const parsedData = Object.assign({}, data);
 
-    for (const field of Object.keys(parsedData)) {
-      if (parsedData[field]) {
-        if (parsedData[field] instanceof DocumentReference) {
-          parsedData[field] = (0, _path.buildPathFromReference)(parsedData[field]);
-        }
+    var _iteratorNormalCompletion2 = true;
+    var _didIteratorError2 = false;
+    var _iteratorError2 = undefined;
 
-        if (typeof parsedData[field] === 'object' && Object.prototype.hasOwnProperty.call(parsedData[field], 'methodName') && parsedData[field].methodName === 'FieldValue.serverTimestamp') {
-          parsedData[field] = new Date();
+    try {
+      for (var _iterator2 = Object.keys(parsedData)[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+        const field = _step2.value;
+
+        if (parsedData[field]) {
+          if (parsedData[field] instanceof DocumentReference) {
+            parsedData[field] = (0, _path.buildPathFromReference)(parsedData[field]);
+          }
+
+          if (typeof parsedData[field] === 'object' && Object.prototype.hasOwnProperty.call(parsedData[field], 'methodName') && parsedData[field].methodName === 'FieldValue.serverTimestamp') {
+            parsedData[field] = new Date();
+          }
+        }
+      }
+    } catch (err) {
+      _didIteratorError2 = true;
+      _iteratorError2 = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion2 && _iterator2.return) {
+          _iterator2.return();
+        }
+      } finally {
+        if (_didIteratorError2) {
+          throw _iteratorError2;
         }
       }
     }
@@ -106,14 +148,35 @@ class DocumentReference {
 
     const parsedData = Object.assign({}, data);
 
-    for (const field of Object.keys(parsedData)) {
-      if (parsedData[field]) {
-        if (parsedData[field] instanceof DocumentReference) {
-          parsedData[field] = (0, _path.buildPathFromReference)(parsedData[field]);
-        }
+    var _iteratorNormalCompletion3 = true;
+    var _didIteratorError3 = false;
+    var _iteratorError3 = undefined;
 
-        if (typeof parsedData[field] === 'object' && Object.prototype.hasOwnProperty.call(parsedData[field], 'methodName') && parsedData[field].methodName === 'FieldValue.serverTimestamp') {
-          parsedData[field] = new Date();
+    try {
+      for (var _iterator3 = Object.keys(parsedData)[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+        const field = _step3.value;
+
+        if (parsedData[field]) {
+          if (parsedData[field] instanceof DocumentReference) {
+            parsedData[field] = (0, _path.buildPathFromReference)(parsedData[field]);
+          }
+
+          if (typeof parsedData[field] === 'object' && Object.prototype.hasOwnProperty.call(parsedData[field], 'methodName') && parsedData[field].methodName === 'FieldValue.serverTimestamp') {
+            parsedData[field] = new Date();
+          }
+        }
+      }
+    } catch (err) {
+      _didIteratorError3 = true;
+      _iteratorError3 = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion3 && _iterator3.return) {
+          _iterator3.return();
+        }
+      } finally {
+        if (_didIteratorError3) {
+          throw _iteratorError3;
         }
       }
     }

--- a/dist/node/firebase/firestore/document-snapshot/index.js
+++ b/dist/node/firebase/firestore/document-snapshot/index.js
@@ -1,8 +1,15 @@
 'use strict';
 
-Object.defineProperty(exports, "__esModule", {
+(Object.defineProperty(exports, "__esModule", {
   value: true
-});
+}), function _objectEntries(obj) {
+  var entries = [];
+  var keys = Object.keys(obj);
+
+  for (var k = 0; k < keys.length; ++k) entries.push([keys[k], obj[keys[k]]]);
+
+  return entries;
+})
 class DocumentSnapshot {
   constructor(id, data, ref) {
     this._id = id;
@@ -35,12 +42,33 @@ class DocumentSnapshot {
     const keys = path.split('.');
     let data = this._getData();
 
-    for (const key of keys) {
-      if (Object.prototype.hasOwnProperty.call(data, key)) {
-        data = data[key];
-      } else {
-        data = undefined;
-        break;
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+      for (var _iterator = keys[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+        const key = _step.value;
+
+        if (Object.prototype.hasOwnProperty.call(data, key)) {
+          data = data[key];
+        } else {
+          data = undefined;
+          break;
+        }
+      }
+    } catch (err) {
+      _didIteratorError = true;
+      _iteratorError = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion && _iterator.return) {
+          _iterator.return();
+        }
+      } finally {
+        if (_didIteratorError) {
+          throw _iteratorError;
+        }
       }
     }
 
@@ -64,7 +92,7 @@ class DocumentSnapshot {
       return o;
     } else if (typeof o === 'object' && o !== null) {
       if (o.constructor === Object) {
-        return Object.entries(o).reduce((accumulator, [key, value]) => {
+        return _objectEntries(o).reduce((accumulator, [key, value]) => {
           if (key === '__collection__' || key === '__doc__') {
             return Object.assign({}, accumulator, this._traverseObject.call(this, value));
           } else {

--- a/dist/node/firebase/firestore/query-snapshot/index.js
+++ b/dist/node/firebase/firestore/query-snapshot/index.js
@@ -21,8 +21,29 @@ class QuerySnapshot {
   }
 
   forEach(callback) {
-    for (const data of this._data) {
-      callback(data);
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+      for (var _iterator = this._data[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+        const data = _step.value;
+
+        callback(data);
+      }
+    } catch (err) {
+      _didIteratorError = true;
+      _iteratorError = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion && _iterator.return) {
+          _iterator.return();
+        }
+      } finally {
+        if (_didIteratorError) {
+          throw _iteratorError;
+        }
+      }
     }
   }
 }

--- a/dist/node/firebase/firestore/write-batch/index.js
+++ b/dist/node/firebase/firestore/write-batch/index.js
@@ -9,16 +9,79 @@ class WriteBatch {
   }
 
   commit() {
-    for (const write of this._writeBatch.set) {
-      write.ref.set(write.data, write.option);
+    var _iteratorNormalCompletion = true;
+    var _didIteratorError = false;
+    var _iteratorError = undefined;
+
+    try {
+      for (var _iterator = this._writeBatch.set[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+        const write = _step.value;
+
+        write.ref.set(write.data, write.option);
+      }
+    } catch (err) {
+      _didIteratorError = true;
+      _iteratorError = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion && _iterator.return) {
+          _iterator.return();
+        }
+      } finally {
+        if (_didIteratorError) {
+          throw _iteratorError;
+        }
+      }
     }
 
-    for (const write of this._writeBatch.update) {
-      write.ref.update(write.data);
+    var _iteratorNormalCompletion2 = true;
+    var _didIteratorError2 = false;
+    var _iteratorError2 = undefined;
+
+    try {
+      for (var _iterator2 = this._writeBatch.update[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+        const write = _step2.value;
+
+        write.ref.update(write.data);
+      }
+    } catch (err) {
+      _didIteratorError2 = true;
+      _iteratorError2 = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion2 && _iterator2.return) {
+          _iterator2.return();
+        }
+      } finally {
+        if (_didIteratorError2) {
+          throw _iteratorError2;
+        }
+      }
     }
 
-    for (const ref of this._writeBatch.delete) {
-      ref.delete();
+    var _iteratorNormalCompletion3 = true;
+    var _didIteratorError3 = false;
+    var _iteratorError3 = undefined;
+
+    try {
+      for (var _iterator3 = this._writeBatch.delete[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+        const ref = _step3.value;
+
+        ref.delete();
+      }
+    } catch (err) {
+      _didIteratorError3 = true;
+      _iteratorError3 = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion3 && _iterator3.return) {
+          _iterator3.return();
+        }
+      } finally {
+        if (_didIteratorError3) {
+          throw _iteratorError3;
+        }
+      }
     }
 
     return Promise.resolve();

--- a/dist/node/unit-test.js
+++ b/dist/node/unit-test.js
@@ -534,7 +534,13 @@ QUnit.module('Unit | mock-cloud-firestore', hooks => {
 
           // Assert
           const snapshot = yield ref.get();
-          const { dad, modifiedOn, name } = snapshot.data();
+
+          var _snapshot$data = snapshot.data();
+
+          const dad = _snapshot$data.dad,
+                modifiedOn = _snapshot$data.modifiedOn,
+                name = _snapshot$data.name;
+
 
           assert.deepEqual(dad, db.collection('users').doc('user_b'));
           assert.ok(modifiedOn.toDate() instanceof Date);
@@ -563,7 +569,13 @@ QUnit.module('Unit | mock-cloud-firestore', hooks => {
 
           // Assert
           const snapshot = yield ref.get();
-          const { dad, modifiedOn, username } = snapshot.data();
+
+          var _snapshot$data2 = snapshot.data();
+
+          const dad = _snapshot$data2.dad,
+                modifiedOn = _snapshot$data2.modifiedOn,
+                username = _snapshot$data2.username;
+
 
           assert.deepEqual(dad, db.collection('users').doc('user_b'));
           assert.ok(modifiedOn.toDate() instanceof Date);
@@ -592,15 +604,17 @@ QUnit.module('Unit | mock-cloud-firestore', hooks => {
 
           // Assert
           const snapshot = yield ref.get();
-          const {
-            address,
-            age,
-            createdOn,
-            dad,
-            modifiedOn,
-            name,
-            username
-          } = snapshot.data();
+
+          var _snapshot$data3 = snapshot.data();
+
+          const address = _snapshot$data3.address,
+                age = _snapshot$data3.age,
+                createdOn = _snapshot$data3.createdOn,
+                dad = _snapshot$data3.dad,
+                modifiedOn = _snapshot$data3.modifiedOn,
+                name = _snapshot$data3.name,
+                username = _snapshot$data3.username;
+
 
           assert.deepEqual(address, { home: 'San Francisco', work: 'Silicon Valley' });
           assert.equal(age, 15);
@@ -635,15 +649,17 @@ QUnit.module('Unit | mock-cloud-firestore', hooks => {
 
           // Assert
           const snapshot = yield ref.get();
-          const {
-            address,
-            age,
-            createdOn,
-            dad,
-            modifiedOn,
-            name,
-            username
-          } = snapshot.data();
+
+          var _snapshot$data4 = snapshot.data();
+
+          const address = _snapshot$data4.address,
+                age = _snapshot$data4.age,
+                createdOn = _snapshot$data4.createdOn,
+                dad = _snapshot$data4.dad,
+                modifiedOn = _snapshot$data4.modifiedOn,
+                name = _snapshot$data4.name,
+                username = _snapshot$data4.username;
+
 
           assert.deepEqual(address, { home: 'San Francisco', work: 'Silicon Valley' });
           assert.equal(age, 15);
@@ -804,7 +820,13 @@ QUnit.module('Unit | mock-cloud-firestore', hooks => {
 
           // Assert
           const referenceSnapshot = yield reference.get();
-          const { age, createdOn, username } = referenceSnapshot.data();
+
+          var _referenceSnapshot$da = referenceSnapshot.data();
+
+          const age = _referenceSnapshot$da.age,
+                createdOn = _referenceSnapshot$da.createdOn,
+                username = _referenceSnapshot$da.username;
+
 
           assert.equal(age, 10);
           assert.deepEqual(createdOn.toDate(), new Date('2017-01-01'));
@@ -867,14 +889,16 @@ QUnit.module('Unit | mock-cloud-firestore', hooks => {
           const snapshot = yield db.collection('users').doc('user_a').get();
 
           // Act
-          const {
-            address,
-            age,
-            createdOn,
-            username
-          } = snapshot.data();
+
+          var _snapshot$data5 = snapshot.data();
+
+          const address = _snapshot$data5.address,
+                age = _snapshot$data5.age,
+                createdOn = _snapshot$data5.createdOn,
+                username = _snapshot$data5.username;
 
           // Assert
+
           assert.deepEqual(address, { home: 'San Francisco', work: 'Silicon Valley' });
           assert.equal(age, 15);
           assert.deepEqual(createdOn.toDate(), new Date('2017-01-01'));
@@ -892,10 +916,12 @@ QUnit.module('Unit | mock-cloud-firestore', hooks => {
           // Arrange
           const db = mockFirebase.firestore();
           const snapshot = yield db.collection('users').doc('user_d').get();
-          const {
-            location,
-            family
-          } = snapshot.data();
+
+          var _snapshot$data6 = snapshot.data();
+
+          const location = _snapshot$data6.location,
+                family = _snapshot$data6.family;
+
 
           assert.deepEqual(location, { country: 'Australia', state: 'VIC' });
           assert.ok(family.parent instanceof _documentReference2.default);
@@ -915,11 +941,21 @@ QUnit.module('Unit | mock-cloud-firestore', hooks => {
           const snapshot = yield db.collection('users').doc('user_a').collection('friends').doc('user_b').get();
 
           // Act
-          const { reference } = snapshot.data();
+
+          var _snapshot$data7 = snapshot.data();
+
+          const reference = _snapshot$data7.reference;
 
           // Assert
+
           const referenceSnapshot = yield reference.get();
-          const { age, createdOn, username } = referenceSnapshot.data();
+
+          var _referenceSnapshot$da2 = referenceSnapshot.data();
+
+          const age = _referenceSnapshot$da2.age,
+                createdOn = _referenceSnapshot$da2.createdOn,
+                username = _referenceSnapshot$da2.username;
+
 
           assert.equal(age, 10);
           assert.deepEqual(createdOn.toDate(), new Date('2017-01-01'));
@@ -1448,12 +1484,13 @@ QUnit.module('Unit | mock-cloud-firestore', hooks => {
           assert.deepEqual(snapshot1.data(), { username: 'new_user' });
           assert.equal(snapshot2.exists, false);
 
-          const {
-            age: snapshot3Age,
-            createdOn: snapshot3CreatedOn,
-            name: snapshot3Name,
-            username: snapshot3Username
-          } = snapshot3.data();
+          var _snapshot3$data = snapshot3.data();
+
+          const snapshot3Age = _snapshot3$data.age,
+                snapshot3CreatedOn = _snapshot3$data.createdOn,
+                snapshot3Name = _snapshot3$data.name,
+                snapshot3Username = _snapshot3$data.username;
+
 
           assert.equal(snapshot3Age, 10);
           assert.deepEqual(snapshot3CreatedOn.toDate(), new Date('2017-01-01'));

--- a/dist/node/unit-test.js
+++ b/dist/node/unit-test.js
@@ -51,1399 +51,1421 @@ function _asyncToGenerator(fn) { return function () { var gen = fn.apply(this, a
 let mockFirebase;
 
 QUnit.module('Unit | mock-cloud-firestore', hooks => {
-        hooks.beforeEach(() => {
-                mockFirebase = new _2.default((0, _fixtureData2.default)());
+  hooks.beforeEach(() => {
+    mockFirebase = new _2.default((0, _fixtureData2.default)());
+  });
+
+  QUnit.module('CollectionReference', () => {
+    QUnit.module('getter/setter: id', () => {
+      QUnit.test('should return collection identifier', assert => {
+        assert.expect(1);
+
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = db.collection('users').id;
+
+        // Assert
+        assert.equal(result, 'users');
+      });
+    });
+
+    QUnit.module('getter/setter: firestore', () => {
+      QUnit.test('should return the firestore the collection is in', assert => {
+        assert.expect(1);
+
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = db.collection('users').firestore;
+
+        // Assert
+        assert.ok(result instanceof _firestore2.default);
+      });
+    });
+
+    QUnit.module('getter/setter: parent', () => {
+      QUnit.test('should return DocumentReference if this is a subcollection', assert => {
+        assert.expect(1);
+
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = db.collection('users').doc('user_a').collection('friends').parent;
+
+        // Assert
+        assert.ok(result instanceof _documentReference2.default);
+      });
+
+      QUnit.test('should return null if there is no parent', assert => {
+        assert.expect(1);
+
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = db.collection('users').parent;
+
+        // Assert
+        assert.equal(result, null);
+      });
+    });
+
+    QUnit.module('function: add', () => {
+      QUnit.test('should add a new document', (() => {
+        var _ref = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+
+          // Act
+          const ref = yield db.collection('users').add({ username: 'new_user' });
+
+          // Assert
+          const snapshot = yield ref.get();
+
+          assert.deepEqual(snapshot.data(), { username: 'new_user' });
         });
 
-        QUnit.module('CollectionReference', () => {
-                QUnit.module('getter/setter: id', () => {
-                        QUnit.test('should return collection identifier', assert => {
-                                assert.expect(1);
+        return function (_x) {
+          return _ref.apply(this, arguments);
+        };
+      })());
+    });
 
-                                // Arrange
-                                const db = mockFirebase.firestore();
+    QUnit.module('function: doc', () => {
+      QUnit.test('should return the document reference using an ID', assert => {
+        assert.expect(1);
 
-                                // Act
-                                const result = db.collection('users').id;
+        // Arrange
+        const db = mockFirebase.firestore();
 
-                                // Assert
-                                assert.equal(result, 'users');
-                        });
-                });
+        // Act
+        const result = db.collection('users').doc('user_a');
 
-                QUnit.module('getter/setter: firestore', () => {
-                        QUnit.test('should return the firestore the collection is in', assert => {
-                                assert.expect(1);
+        // Assert
+        assert.ok(result instanceof _documentReference2.default);
+      });
 
-                                // Arrange
-                                const db = mockFirebase.firestore();
+      QUnit.test('should return the document reference using a path', assert => {
+        assert.expect(2);
 
-                                // Act
-                                const result = db.collection('users').firestore;
+        // Arrange
+        const db = mockFirebase.firestore();
 
-                                // Assert
-                                assert.ok(result instanceof _firestore2.default);
-                        });
-                });
+        // Act
+        const result = db.collection('users').doc('user_a/friends/user_b');
 
-                QUnit.module('getter/setter: parent', () => {
-                        QUnit.test('should return DocumentReference if this is a subcollection', assert => {
-                                assert.expect(1);
+        // Assert
+        assert.ok(result instanceof _documentReference2.default);
+        assert.equal(result.id, 'user_b');
+      });
 
-                                // Arrange
-                                const db = mockFirebase.firestore();
+      QUnit.test('should create document reference when not providing an ID', assert => {
+        assert.expect(1);
 
-                                // Act
-                                const result = db.collection('users').doc('user_a').collection('friends').parent;
+        // Arrange
+        const db = mockFirebase.firestore();
 
-                                // Assert
-                                assert.ok(result instanceof _documentReference2.default);
-                        });
+        // Act
+        const result = db.collection('users').doc();
 
-                        QUnit.test('should return null if there is no parent', assert => {
-                                assert.expect(1);
+        // Assert
+        assert.ok(result.id);
+      });
+    });
 
-                                // Arrange
-                                const db = mockFirebase.firestore();
+    QUnit.module('function: endAt', () => {
+      QUnit.test('should return an instance of Query', assert => {
+        assert.expect(1);
 
-                                // Act
-                                const result = db.collection('users').parent;
+        // Arrange
+        const db = mockFirebase.firestore();
 
-                                // Assert
-                                assert.equal(result, null);
-                        });
-                });
+        // Act
+        const result = db.collection('users').orderBy('age').endAt(15);
 
-                QUnit.module('function: add', () => {
-                        QUnit.test('should add a new document', (() => {
-                                var _ref = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
+        // Assert
+        assert.ok(result instanceof _query2.default);
+      });
+    });
 
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
+    QUnit.module('function: endBefore', () => {
+      QUnit.test('should return an instance of Query', assert => {
+        assert.expect(1);
 
-                                        // Act
-                                        const ref = yield db.collection('users').add({ username: 'new_user' });
+        // Arrange
+        const db = mockFirebase.firestore();
 
-                                        // Assert
-                                        const snapshot = yield ref.get();
+        // Act
+        const result = db.collection('users').orderBy('age').endBefore(15);
 
-                                        assert.deepEqual(snapshot.data(), { username: 'new_user' });
-                                });
+        // Assert
+        assert.ok(result instanceof _query2.default);
+      });
+    });
 
-                                return function (_x) {
-                                        return _ref.apply(this, arguments);
-                                };
-                        })());
-                });
+    QUnit.module('function: get', () => {
+      QUnit.test('should return the query snapshot', (() => {
+        var _ref2 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
 
-                QUnit.module('function: doc', () => {
-                        QUnit.test('should return the document reference using an ID', assert => {
-                                assert.expect(1);
+          // Arrange
+          const db = mockFirebase.firestore();
 
-                                // Arrange
-                                const db = mockFirebase.firestore();
+          // Act
+          const result = yield db.collection('users').get();
 
-                                // Act
-                                const result = db.collection('users').doc('user_a');
-
-                                // Assert
-                                assert.ok(result instanceof _documentReference2.default);
-                        });
-
-                        QUnit.test('should return the document reference using a path', assert => {
-                                assert.expect(2);
-
-                                // Arrange
-                                const db = mockFirebase.firestore();
-
-                                // Act
-                                const result = db.collection('users').doc('user_a/friends/user_b');
-
-                                // Assert
-                                assert.ok(result instanceof _documentReference2.default);
-                                assert.equal(result.id, 'user_b');
-                        });
-
-                        QUnit.test('should create document reference when not providing an ID', assert => {
-                                assert.expect(1);
-
-                                // Arrange
-                                const db = mockFirebase.firestore();
-
-                                // Act
-                                const result = db.collection('users').doc();
-
-                                // Assert
-                                assert.ok(result.id);
-                        });
-                });
-
-                QUnit.module('function: endAt', () => {
-                        QUnit.test('should return an instance of Query', assert => {
-                                assert.expect(1);
-
-                                // Arrange
-                                const db = mockFirebase.firestore();
-
-                                // Act
-                                const result = db.collection('users').orderBy('age').endAt(15);
-
-                                // Assert
-                                assert.ok(result instanceof _query2.default);
-                        });
-                });
-
-                QUnit.module('function: endBefore', () => {
-                        QUnit.test('should return an instance of Query', assert => {
-                                assert.expect(1);
-
-                                // Arrange
-                                const db = mockFirebase.firestore();
-
-                                // Act
-                                const result = db.collection('users').orderBy('age').endBefore(15);
-
-                                // Assert
-                                assert.ok(result instanceof _query2.default);
-                        });
-                });
-
-                QUnit.module('function: get', () => {
-                        QUnit.test('should return the query snapshot', (() => {
-                                var _ref2 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-
-                                        // Act
-                                        const result = yield db.collection('users').get();
-
-                                        // Assert
-                                        assert.ok(result instanceof _querySnapshot2.default);
-                                });
-
-                                return function (_x2) {
-                                        return _ref2.apply(this, arguments);
-                                };
-                        })());
-                });
-
-                QUnit.module('function: limit', () => {
-                        QUnit.test('should return an instance of Query', assert => {
-                                assert.expect(1);
-
-                                // Arrange
-                                const db = mockFirebase.firestore();
-
-                                // Act
-                                const result = db.collection('users').orderBy('age').limit(15);
-
-                                // Assert
-                                assert.ok(result instanceof _query2.default);
-                        });
-                });
-
-                QUnit.module('function: onSnapshot', () => {
-                        QUnit.test('should return a function for unsubscribing', assert => {
-                                assert.expect(1);
-
-                                // Arrange
-                                const db = mockFirebase.firestore();
-
-                                // Act
-                                const result = db.collection('users').onSnapshot(() => {});
-
-                                // Assert
-                                assert.ok(typeof result === 'function');
-                        });
-
-                        QUnit.test('should fire callback', assert => {
-                                assert.expect(1);
-
-                                // Arrange
-                                const done = assert.async();
-                                const db = mockFirebase.firestore();
-
-                                // Act
-                                db.collection('users').onSnapshot(snapshot => {
-                                        // Assert
-                                        assert.ok(snapshot instanceof _querySnapshot2.default);
-                                        done();
-                                });
-                        });
-                });
-
-                QUnit.module('function: orderBy', () => {
-                        QUnit.test('should return an instance of Query', assert => {
-                                assert.expect(1);
-
-                                // Arrange
-                                const db = mockFirebase.firestore();
-
-                                // Act
-                                const result = db.collection('users').orderBy('age');
-
-                                // Assert
-                                assert.ok(result instanceof _query2.default);
-                        });
-                });
-
-                QUnit.module('function: startAfter', () => {
-                        QUnit.test('should return an instance of Query', assert => {
-                                assert.expect(1);
-
-                                // Arrange
-                                const db = mockFirebase.firestore();
-
-                                // Act
-                                const result = db.collection('users').orderBy('age').startAfter(15);
-
-                                // Assert
-                                assert.ok(result instanceof _query2.default);
-                        });
-                });
-
-                QUnit.module('function: startAt', () => {
-                        QUnit.test('should return an instance of Query', assert => {
-                                assert.expect(1);
-
-                                // Arrange
-                                const db = mockFirebase.firestore();
-
-                                // Act
-                                const result = db.collection('users').orderBy('age').startAt(15);
-
-                                // Assert
-                                assert.ok(result instanceof _query2.default);
-                        });
-                });
-
-                QUnit.module('function: where', () => {
-                        QUnit.test('should return an instance of Query', assert => {
-                                assert.expect(1);
-
-                                // Arrange
-                                const db = mockFirebase.firestore();
-
-                                // Act
-                                const result = db.collection('users').orderBy('age').where('name', '==', 'Foo');
-
-                                // Assert
-                                assert.ok(result instanceof _query2.default);
-                        });
-                });
+          // Assert
+          assert.ok(result instanceof _querySnapshot2.default);
         });
 
-        QUnit.module('DocumentReference', () => {
-                QUnit.module('getter/setter: id', () => {
-                        QUnit.test('should return document identifier', assert => {
-                                assert.expect(1);
+        return function (_x2) {
+          return _ref2.apply(this, arguments);
+        };
+      })());
+    });
+
+    QUnit.module('function: limit', () => {
+      QUnit.test('should return an instance of Query', assert => {
+        assert.expect(1);
+
+        // Arrange
+        const db = mockFirebase.firestore();
 
-                                // Arrange
-                                const db = mockFirebase.firestore();
+        // Act
+        const result = db.collection('users').orderBy('age').limit(15);
+
+        // Assert
+        assert.ok(result instanceof _query2.default);
+      });
+    });
 
-                                // Act
-                                const result = db.collection('users').doc('user_a').id;
+    QUnit.module('function: onSnapshot', () => {
+      QUnit.test('should return a function for unsubscribing', assert => {
+        assert.expect(1);
 
-                                // Assert
-                                assert.equal(result, 'user_a');
-                        });
-                });
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = db.collection('users').onSnapshot(() => {});
+
+        // Assert
+        assert.ok(typeof result === 'function');
+      });
+
+      QUnit.test('should fire callback', assert => {
+        assert.expect(1);
+
+        // Arrange
+        const done = assert.async();
+        const db = mockFirebase.firestore();
+
+        // Act
+        db.collection('users').onSnapshot(snapshot => {
+          // Assert
+          assert.ok(snapshot instanceof _querySnapshot2.default);
+          done();
+        });
+      });
+    });
 
-                QUnit.module('getter/setter: firestore', () => {
-                        QUnit.test('should return the firestore the document is in', assert => {
-                                assert.expect(1);
+    QUnit.module('function: orderBy', () => {
+      QUnit.test('should return an instance of Query', assert => {
+        assert.expect(1);
 
-                                // Arrange
-                                const db = mockFirebase.firestore();
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = db.collection('users').orderBy('age');
 
-                                // Act
-                                const result = db.collection('users').doc('user_a').firestore;
+        // Assert
+        assert.ok(result instanceof _query2.default);
+      });
+    });
 
-                                // Assert
-                                assert.ok(result instanceof _firestore2.default);
-                        });
-                });
+    QUnit.module('function: startAfter', () => {
+      QUnit.test('should return an instance of Query', assert => {
+        assert.expect(1);
 
-                QUnit.module('getter/setter: parent', () => {
-                        QUnit.test('should return CollectionReference of which the DocumentReference belongs to', assert => {
-                                assert.expect(1);
+        // Arrange
+        const db = mockFirebase.firestore();
 
-                                // Arrange
-                                const db = mockFirebase.firestore();
+        // Act
+        const result = db.collection('users').orderBy('age').startAfter(15);
 
-                                // Act
-                                const result = db.collection('users').doc('user_a').parent;
+        // Assert
+        assert.ok(result instanceof _query2.default);
+      });
+    });
 
-                                // Assert
-                                assert.ok(result instanceof _collectionReference2.default);
-                        });
-                });
+    QUnit.module('function: startAt', () => {
+      QUnit.test('should return an instance of Query', assert => {
+        assert.expect(1);
 
-                QUnit.module('function: collection', () => {
-                        QUnit.test('should return the collection reference of an ID', assert => {
-                                assert.expect(1);
-
-                                // Arrange
-                                const db = mockFirebase.firestore();
+        // Arrange
+        const db = mockFirebase.firestore();
 
-                                // Act
-                                const result = db.collection('users').doc('user_a').collection('friends');
+        // Act
+        const result = db.collection('users').orderBy('age').startAt(15);
 
-                                // Assert
-                                assert.ok(result instanceof _collectionReference2.default);
-                        });
+        // Assert
+        assert.ok(result instanceof _query2.default);
+      });
+    });
 
-                        QUnit.test('should return the collection reference of a path', assert => {
-                                assert.expect(2);
+    QUnit.module('function: where', () => {
+      QUnit.test('should return an instance of Query', assert => {
+        assert.expect(1);
 
-                                // Arrange
-                                const db = mockFirebase.firestore();
+        // Arrange
+        const db = mockFirebase.firestore();
 
-                                // Act
-                                const result = db.collection('users').doc('user_a').collection('friends/user_b/wew_so_deep');
+        // Act
+        const result = db.collection('users').orderBy('age').where('name', '==', 'Foo');
 
-                                // Assert
-                                assert.ok(result instanceof _collectionReference2.default);
-                                assert.equal(result.id, 'wew_so_deep');
-                        });
-                });
+        // Assert
+        assert.ok(result instanceof _query2.default);
+      });
+    });
+  });
 
-                QUnit.module('function: delete', () => {
-                        QUnit.test('should delete the document', (() => {
-                                var _ref3 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const ref = db.collection('users').doc('user_a');
-
-                                        // Act
-                                        yield ref.delete();
-
-                                        // Assert
-                                        const record = yield ref.get();
-
-                                        assert.equal(record.exists, false);
-                                });
-
-                                return function (_x3) {
-                                        return _ref3.apply(this, arguments);
-                                };
-                        })());
-
-                        QUnit.test('should delete the document coming from a query', (() => {
-                                var _ref4 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const querySnapshot = yield db.collection('users').where('age', '==', 15).get();
-
-                                        // Act
-                                        querySnapshot.forEach((() => {
-                                                var _ref5 = _asyncToGenerator(function* (docSnapshot) {
-                                                        yield docSnapshot.ref.delete();
-                                                });
-
-                                                return function (_x5) {
-                                                        return _ref5.apply(this, arguments);
-                                                };
-                                        })());
-
-                                        // Assert
-                                        const docSnapshot = yield db.collection('users').doc('user_a').get();
-
-                                        assert.equal(docSnapshot.exists, false);
-                                });
-
-                                return function (_x4) {
-                                        return _ref4.apply(this, arguments);
-                                };
-                        })());
-                });
-
-                QUnit.module('function: get', () => {
-                        QUnit.test('should return the document snapshot', (() => {
-                                var _ref6 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-
-                                        // Act
-                                        const result = yield db.collection('users').doc('user_a').get();
-
-                                        // Assert
-                                        assert.ok(result instanceof _documentSnapshot2.default);
-                                });
-
-                                return function (_x6) {
-                                        return _ref6.apply(this, arguments);
-                                };
-                        })());
-                });
-
-                QUnit.module('function: onSnapshot', () => {
-                        QUnit.test('should return a function for unsubscribing', assert => {
-                                assert.expect(1);
-
-                                // Arrange
-                                const db = mockFirebase.firestore();
-
-                                // Act
-                                const result = db.collection('users').doc('user_a').onSnapshot(() => {});
-
-                                // Assert
-                                assert.ok(typeof result === 'function');
-                        });
-
-                        QUnit.test('should fire callback', assert => {
-                                assert.expect(1);
-
-                                // Arrange
-                                const done = assert.async();
-                                const db = mockFirebase.firestore();
-
-                                // Act
-                                db.collection('users').doc('user_a').onSnapshot(snapshot => {
-                                        // Assert
-                                        assert.ok(snapshot instanceof _documentSnapshot2.default);
-                                        done();
-                                });
-                        });
-                });
-
-                QUnit.module('function: set', () => {
-                        QUnit.test('should set the data using the default options when it exist', (() => {
-                                var _ref7 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(3);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const ref = db.collection('users').doc('user_a');
-
-                                        // Act
-                                        yield ref.set({
-                                                name: 'user_a',
-                                                dad: db.collection('users').doc('user_b'),
-                                                modifiedOn: _firebase2.default.firestore.FieldValue.serverTimestamp()
-                                        });
-
-                                        // Assert
-                                        const snapshot = yield ref.get();
-                                        const { dad, modifiedOn, name } = snapshot.data();
-
-                                        assert.deepEqual(dad, db.collection('users').doc('user_b'));
-                                        assert.ok(modifiedOn.toDate() instanceof Date);
-                                        assert.equal(name, 'user_a');
-                                });
-
-                                return function (_x7) {
-                                        return _ref7.apply(this, arguments);
-                                };
-                        })());
-
-                        QUnit.test('should set the data using the default options when it does not exists', (() => {
-                                var _ref8 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(3);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const ref = db.collection('users').doc('user_100');
-
-                                        // Act
-                                        yield ref.set({
-                                                dad: db.collection('users').doc('user_b'),
-                                                modifiedOn: _firebase2.default.firestore.FieldValue.serverTimestamp(),
-                                                username: 'user_100'
-                                        });
-
-                                        // Assert
-                                        const snapshot = yield ref.get();
-                                        const { dad, modifiedOn, username } = snapshot.data();
-
-                                        assert.deepEqual(dad, db.collection('users').doc('user_b'));
-                                        assert.ok(modifiedOn.toDate() instanceof Date);
-                                        assert.equal(username, 'user_100');
-                                });
-
-                                return function (_x8) {
-                                        return _ref8.apply(this, arguments);
-                                };
-                        })());
-
-                        QUnit.test('should set the data using the merge option', (() => {
-                                var _ref9 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(7);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const ref = db.collection('users').doc('user_a');
-
-                                        // Act
-                                        yield ref.set({
-                                                dad: db.collection('users').doc('user_b'),
-                                                modifiedOn: _firebase2.default.firestore.FieldValue.serverTimestamp(),
-                                                name: 'user_a'
-                                        }, { merge: true });
-
-                                        // Assert
-                                        const snapshot = yield ref.get();
-                                        const {
-                                                address,
-                                                age,
-                                                createdOn,
-                                                dad,
-                                                modifiedOn,
-                                                name,
-                                                username
-                                        } = snapshot.data();
-
-                                        assert.deepEqual(address, { home: 'San Francisco', work: 'Silicon Valley' });
-                                        assert.equal(age, 15);
-                                        assert.deepEqual(createdOn.toDate(), new Date('2017-01-01'));
-                                        assert.deepEqual(dad, db.collection('users').doc('user_b'));
-                                        assert.ok(modifiedOn.toDate() instanceof Date);
-                                        assert.equal(name, 'user_a');
-                                        assert.equal(username, 'user_a');
-                                });
-
-                                return function (_x9) {
-                                        return _ref9.apply(this, arguments);
-                                };
-                        })());
-                });
-
-                QUnit.module('function: update', () => {
-                        QUnit.test('should update the data', (() => {
-                                var _ref10 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(7);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const ref = db.collection('users').doc('user_a');
-
-                                        // Act
-                                        yield ref.update({
-                                                dad: db.collection('users').doc('user_b'),
-                                                modifiedOn: _firebase2.default.firestore.FieldValue.serverTimestamp(),
-                                                name: 'user_a'
-                                        });
-
-                                        // Assert
-                                        const snapshot = yield ref.get();
-                                        const {
-                                                address,
-                                                age,
-                                                createdOn,
-                                                dad,
-                                                modifiedOn,
-                                                name,
-                                                username
-                                        } = snapshot.data();
-
-                                        assert.deepEqual(address, { home: 'San Francisco', work: 'Silicon Valley' });
-                                        assert.equal(age, 15);
-                                        assert.deepEqual(createdOn.toDate(), new Date('2017-01-01'));
-                                        assert.deepEqual(dad, db.collection('users').doc('user_b'));
-                                        assert.ok(modifiedOn.toDate() instanceof Date);
-                                        assert.equal(name, 'user_a');
-                                        assert.equal(username, 'user_a');
-                                });
-
-                                return function (_x10) {
-                                        return _ref10.apply(this, arguments);
-                                };
-                        })());
-
-                        QUnit.test('should throw error when updating data that does not exist', (() => {
-                                var _ref11 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const ref = db.collection('users').doc('user_100');
-
-                                        try {
-                                                // Act
-                                                yield ref.update({ name: 'user_100' });
-                                        } catch (e) {
-                                                // Assert
-                                                assert.ok(true);
-                                        }
-                                });
-
-                                return function (_x11) {
-                                        return _ref11.apply(this, arguments);
-                                };
-                        })());
-                });
+  QUnit.module('DocumentReference', () => {
+    QUnit.module('getter/setter: id', () => {
+      QUnit.test('should return document identifier', assert => {
+        assert.expect(1);
+
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = db.collection('users').doc('user_a').id;
+
+        // Assert
+        assert.equal(result, 'user_a');
+      });
+    });
+
+    QUnit.module('getter/setter: firestore', () => {
+      QUnit.test('should return the firestore the document is in', assert => {
+        assert.expect(1);
+
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = db.collection('users').doc('user_a').firestore;
+
+        // Assert
+        assert.ok(result instanceof _firestore2.default);
+      });
+    });
+
+    QUnit.module('getter/setter: parent', () => {
+      QUnit.test('should return CollectionReference of which the DocumentReference belongs to', assert => {
+        assert.expect(1);
+
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = db.collection('users').doc('user_a').parent;
+
+        // Assert
+        assert.ok(result instanceof _collectionReference2.default);
+      });
+    });
+
+    QUnit.module('function: collection', () => {
+      QUnit.test('should return the collection reference of an ID', assert => {
+        assert.expect(1);
+
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = db.collection('users').doc('user_a').collection('friends');
+
+        // Assert
+        assert.ok(result instanceof _collectionReference2.default);
+      });
+
+      QUnit.test('should return the collection reference of a path', assert => {
+        assert.expect(2);
+
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = db.collection('users').doc('user_a').collection('friends/user_b/wew_so_deep');
+
+        // Assert
+        assert.ok(result instanceof _collectionReference2.default);
+        assert.equal(result.id, 'wew_so_deep');
+      });
+    });
+
+    QUnit.module('function: delete', () => {
+      QUnit.test('should delete the document', (() => {
+        var _ref3 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const ref = db.collection('users').doc('user_a');
+
+          // Act
+          yield ref.delete();
+
+          // Assert
+          const record = yield ref.get();
+
+          assert.equal(record.exists, false);
         });
 
-        QUnit.module('DocumentSnapshot', () => {
-                QUnit.module('getter/setter: exists', () => {
-                        QUnit.test('should return true if data exists', (() => {
-                                var _ref12 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
+        return function (_x3) {
+          return _ref3.apply(this, arguments);
+        };
+      })());
 
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const snapshot = yield db.collection('users').doc('user_a').get();
+      QUnit.test('should delete the document coming from a query', (() => {
+        var _ref4 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
 
-                                        // Act
-                                        const result = snapshot.exists;
+          // Arrange
+          const db = mockFirebase.firestore();
+          const querySnapshot = yield db.collection('users').where('age', '==', 15).get();
 
-                                        // Assert
-                                        assert.equal(result, true);
-                                });
+          // Act
+          querySnapshot.forEach((() => {
+            var _ref5 = _asyncToGenerator(function* (docSnapshot) {
+              yield docSnapshot.ref.delete();
+            });
 
-                                return function (_x12) {
-                                        return _ref12.apply(this, arguments);
-                                };
-                        })());
+            return function (_x5) {
+              return _ref5.apply(this, arguments);
+            };
+          })());
 
-                        QUnit.test('should return false if data does not exists', (() => {
-                                var _ref13 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
+          // Assert
+          const docSnapshot = yield db.collection('users').doc('user_a').get();
 
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const snapshot = yield db.collection('users').doc('user_100').get();
-
-                                        // Act
-                                        const result = snapshot.exists;
-
-                                        // Assert
-                                        assert.equal(result, false);
-                                });
-
-                                return function (_x13) {
-                                        return _ref13.apply(this, arguments);
-                                };
-                        })());
-                });
-
-                QUnit.module('getter/setter: id', () => {
-                        QUnit.test('should return the identifier', (() => {
-                                var _ref14 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const snapshot = yield db.collection('users').doc('user_a').get();
-
-                                        // Act
-                                        const result = snapshot.id;
-
-                                        // Assert
-                                        assert.equal(result, 'user_a');
-                                });
-
-                                return function (_x14) {
-                                        return _ref14.apply(this, arguments);
-                                };
-                        })());
-                });
-
-                QUnit.module('getter/setter: ref', () => {
-                        QUnit.test('should return the DocumentReference', (() => {
-                                var _ref15 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const snapshot = yield db.collection('users').doc('user_a').get();
-
-                                        // Act
-                                        const result = snapshot.ref;
-
-                                        // Assert
-                                        assert.ok(result instanceof _documentReference2.default);
-                                });
-
-                                return function (_x15) {
-                                        return _ref15.apply(this, arguments);
-                                };
-                        })());
-                });
-
-                QUnit.module('function: get', () => {
-                        QUnit.test('should return the specific field', (() => {
-                                var _ref16 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const snapshot = yield db.collection('users').doc('user_a').get();
-
-                                        // Act
-                                        const result = snapshot.get('age');
-
-                                        // Assert
-                                        assert.equal(result, 15);
-                                });
-
-                                return function (_x16) {
-                                        return _ref16.apply(this, arguments);
-                                };
-                        })());
-
-                        QUnit.test('should return the reference type field', (() => {
-                                var _ref17 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(3);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const snapshot = yield db.collection('users').doc('user_a').collection('friends').doc('user_b').get();
-
-                                        // Act
-                                        const reference = snapshot.get('reference');
-
-                                        // Assert
-                                        const referenceSnapshot = yield reference.get();
-                                        const { age, createdOn, username } = referenceSnapshot.data();
-
-                                        assert.equal(age, 10);
-                                        assert.deepEqual(createdOn.toDate(), new Date('2017-01-01'));
-                                        assert.equal(username, 'user_b');
-                                });
-
-                                return function (_x17) {
-                                        return _ref17.apply(this, arguments);
-                                };
-                        })());
-
-                        QUnit.test('should return the specific field using dot notation', (() => {
-                                var _ref18 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const snapshot = yield db.collection('users').doc('user_a').get();
-
-                                        // Act
-                                        const result = snapshot.get('address.home');
-
-                                        // Assert
-                                        assert.equal(result, 'San Francisco');
-                                });
-
-                                return function (_x18) {
-                                        return _ref18.apply(this, arguments);
-                                };
-                        })());
-
-                        QUnit.test('should return undefined when field does not exist', (() => {
-                                var _ref19 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const snapshot = yield db.collection('users').doc('user_a').get();
-
-                                        // Act
-                                        const result = snapshot.get('foobar');
-
-                                        // Assert
-                                        assert.equal(result, undefined);
-                                });
-
-                                return function (_x19) {
-                                        return _ref19.apply(this, arguments);
-                                };
-                        })());
-                });
-
-                QUnit.module('function: data', () => {
-                        QUnit.test('should return the data', (() => {
-                                var _ref20 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(4);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const snapshot = yield db.collection('users').doc('user_a').get();
-
-                                        // Act
-                                        const {
-                                                address,
-                                                age,
-                                                createdOn,
-                                                username
-                                        } = snapshot.data();
-
-                                        // Assert
-                                        assert.deepEqual(address, { home: 'San Francisco', work: 'Silicon Valley' });
-                                        assert.equal(age, 15);
-                                        assert.deepEqual(createdOn.toDate(), new Date('2017-01-01'));
-                                        assert.equal(username, 'user_a');
-                                });
-
-                                return function (_x20) {
-                                        return _ref20.apply(this, arguments);
-                                };
-                        })());
-
-                        QUnit.test('should return the data and match any reference type field appropriately', (() => {
-                                var _ref21 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(3);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const snapshot = yield db.collection('users').doc('user_a').collection('friends').doc('user_b').get();
-
-                                        // Act
-                                        const { reference } = snapshot.data();
-
-                                        // Assert
-                                        const referenceSnapshot = yield reference.get();
-                                        const { age, createdOn, username } = referenceSnapshot.data();
-
-                                        assert.equal(age, 10);
-                                        assert.deepEqual(createdOn.toDate(), new Date('2017-01-01'));
-                                        assert.equal(username, 'user_b');
-                                });
-
-                                return function (_x21) {
-                                        return _ref21.apply(this, arguments);
-                                };
-                        })());
-
-                        QUnit.test('should return undefined when data does not exist', (() => {
-                                var _ref22 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const snapshot = yield db.collection('users').doc('user_100').get();
-
-                                        // Act
-                                        const result = snapshot.data();
-
-                                        // Assert
-                                        assert.equal(result, undefined);
-                                });
-
-                                return function (_x22) {
-                                        return _ref22.apply(this, arguments);
-                                };
-                        })());
-                });
+          assert.equal(docSnapshot.exists, false);
         });
 
-        QUnit.module('FieldValue', () => {
-                QUnit.module('function: serverTimestamp', () => {
-                        QUnit.test('should return a new date', assert => {
-                                assert.expect(1);
+        return function (_x4) {
+          return _ref4.apply(this, arguments);
+        };
+      })());
+    });
 
-                                // Act
-                                const result = mockFirebase.firestore.FieldValue.serverTimestamp();
+    QUnit.module('function: get', () => {
+      QUnit.test('should return the document snapshot', (() => {
+        var _ref6 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
 
-                                // Assert
-                                assert.ok(result instanceof Date);
-                        });
-                });
+          // Arrange
+          const db = mockFirebase.firestore();
+
+          // Act
+          const result = yield db.collection('users').doc('user_a').get();
+
+          // Assert
+          assert.ok(result instanceof _documentSnapshot2.default);
         });
 
-        QUnit.module('Firestore', () => {
-                QUnit.module('static getter/setter: FieldValue', () => {
-                        QUnit.test('should return an instance of FieldValue', assert => {
-                                assert.expect(1);
+        return function (_x6) {
+          return _ref6.apply(this, arguments);
+        };
+      })());
+    });
 
-                                // Act
-                                const result = mockFirebase.firestore.FieldValue;
+    QUnit.module('function: onSnapshot', () => {
+      QUnit.test('should return a function for unsubscribing', assert => {
+        assert.expect(1);
 
-                                // Assert
-                                assert.ok(result instanceof _fieldValue2.default);
-                        });
-                });
+        // Arrange
+        const db = mockFirebase.firestore();
 
-                QUnit.module('function: collection', () => {
-                        QUnit.test('should return the collection reference using a path', assert => {
-                                assert.expect(2);
+        // Act
+        const result = db.collection('users').doc('user_a').onSnapshot(() => {});
 
-                                // Arrange
-                                const db = mockFirebase.firestore();
+        // Assert
+        assert.ok(typeof result === 'function');
+      });
 
-                                // Act
-                                const result = db.doc('users/user_a/friends');
+      QUnit.test('should fire callback', assert => {
+        assert.expect(1);
 
-                                // Assert
-                                assert.ok(result instanceof _collectionReference2.default);
-                                assert.equal(result.id, 'friends');
-                        });
-                });
+        // Arrange
+        const done = assert.async();
+        const db = mockFirebase.firestore();
 
-                QUnit.module('function: doc', () => {
-                        QUnit.test('should return the document reference using a path', assert => {
-                                assert.expect(2);
+        // Act
+        db.collection('users').doc('user_a').onSnapshot(snapshot => {
+          // Assert
+          assert.ok(snapshot instanceof _documentSnapshot2.default);
+          done();
+        });
+      });
+    });
 
-                                // Arrange
-                                const db = mockFirebase.firestore();
+    QUnit.module('function: set', () => {
+      QUnit.test('should set the data using the default options when it exist', (() => {
+        var _ref7 = _asyncToGenerator(function* (assert) {
+          assert.expect(3);
 
-                                // Act
-                                const result = db.doc('users/user_a');
+          // Arrange
+          const db = mockFirebase.firestore();
+          const ref = db.collection('users').doc('user_a');
 
-                                // Assert
-                                assert.ok(result instanceof _documentReference2.default);
-                                assert.equal(result.id, 'user_a');
-                        });
-                });
+          // Act
+          yield ref.set({
+            name: 'user_a',
+            dad: db.collection('users').doc('user_b'),
+            modifiedOn: _firebase2.default.firestore.FieldValue.serverTimestamp()
+          });
+
+          // Assert
+          const snapshot = yield ref.get();
+          const { dad, modifiedOn, name } = snapshot.data();
+
+          assert.deepEqual(dad, db.collection('users').doc('user_b'));
+          assert.ok(modifiedOn.toDate() instanceof Date);
+          assert.equal(name, 'user_a');
         });
 
-        QUnit.module('QuerySnapshot', () => {
-                QUnit.module('getter/setter: docs', () => {
-                        QUnit.test('should return the documents for the query snapshot', (() => {
-                                var _ref23 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(3);
+        return function (_x7) {
+          return _ref7.apply(this, arguments);
+        };
+      })());
 
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const snapshot = yield db.collection('users').get();
+      QUnit.test('should set the data using the default options when it does not exists', (() => {
+        var _ref8 = _asyncToGenerator(function* (assert) {
+          assert.expect(3);
 
-                                        // Act
-                                        const result = snapshot.docs;
+          // Arrange
+          const db = mockFirebase.firestore();
+          const ref = db.collection('users').doc('user_100');
 
-                                        // Assert
-                                        assert.equal(result[0].id, 'user_a');
-                                        assert.equal(result[1].id, 'user_b');
-                                        assert.equal(result[2].id, 'user_c');
-                                });
+          // Act
+          yield ref.set({
+            dad: db.collection('users').doc('user_b'),
+            modifiedOn: _firebase2.default.firestore.FieldValue.serverTimestamp(),
+            username: 'user_100'
+          });
 
-                                return function (_x23) {
-                                        return _ref23.apply(this, arguments);
-                                };
-                        })());
-                });
+          // Assert
+          const snapshot = yield ref.get();
+          const { dad, modifiedOn, username } = snapshot.data();
 
-                QUnit.module('getter/setter: empty', () => {
-                        QUnit.test('should return true when there are no documents', (() => {
-                                var _ref24 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const snapshot = yield db.collection('foobar').get();
-
-                                        // Act
-                                        const result = snapshot.empty;
-
-                                        // Assert
-                                        assert.equal(result, true);
-                                });
-
-                                return function (_x24) {
-                                        return _ref24.apply(this, arguments);
-                                };
-                        })());
-
-                        QUnit.test('should return false when there are documents', (() => {
-                                var _ref25 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const snapshot = yield db.collection('users').get();
-
-                                        // Act
-                                        const result = snapshot.empty;
-
-                                        // Assert
-                                        assert.equal(result, false);
-                                });
-
-                                return function (_x25) {
-                                        return _ref25.apply(this, arguments);
-                                };
-                        })());
-                });
-
-                QUnit.module('getter/setter: size', () => {
-                        QUnit.test('should return the number of documents for the query snapshot', (() => {
-                                var _ref26 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const snapshot = yield db.collection('users').get();
-
-                                        // Act
-                                        const result = snapshot.size;
-
-                                        // Assert
-                                        assert.equal(result, 3);
-                                });
-
-                                return function (_x26) {
-                                        return _ref26.apply(this, arguments);
-                                };
-                        })());
-                });
-
-                QUnit.module('function: forEach', () => {
-                        QUnit.test('should fire callback per each data', (() => {
-                                var _ref27 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const stub = _sinon2.default.stub();
-                                        const db = mockFirebase.firestore();
-                                        const snapshot = yield db.collection('users').get();
-
-                                        // Act
-                                        snapshot.forEach(stub);
-
-                                        // Assert
-                                        assert.ok(stub.calledThrice);
-                                });
-
-                                return function (_x27) {
-                                        return _ref27.apply(this, arguments);
-                                };
-                        })());
-                });
+          assert.deepEqual(dad, db.collection('users').doc('user_b'));
+          assert.ok(modifiedOn.toDate() instanceof Date);
+          assert.equal(username, 'user_100');
         });
 
-        QUnit.module('Query', () => {
-                QUnit.module('getter/setter: firestore', () => {
-                        QUnit.test('should return the firestore the query is in', assert => {
-                                assert.expect(1);
+        return function (_x8) {
+          return _ref8.apply(this, arguments);
+        };
+      })());
 
-                                // Arrange
-                                const db = mockFirebase.firestore();
+      QUnit.test('should set the data using the merge option', (() => {
+        var _ref9 = _asyncToGenerator(function* (assert) {
+          assert.expect(7);
 
-                                // Act
-                                const result = db.collection('users').limit(1).firestore;
+          // Arrange
+          const db = mockFirebase.firestore();
+          const ref = db.collection('users').doc('user_a');
 
-                                // Assert
-                                assert.ok(result instanceof _firestore2.default);
-                        });
-                });
+          // Act
+          yield ref.set({
+            dad: db.collection('users').doc('user_b'),
+            modifiedOn: _firebase2.default.firestore.FieldValue.serverTimestamp(),
+            name: 'user_a'
+          }, { merge: true });
 
-                QUnit.module('function: endAt', () => {
-                        QUnit.test('should return documents satisfying the query', (() => {
-                                var _ref28 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(3);
+          // Assert
+          const snapshot = yield ref.get();
+          const {
+            address,
+            age,
+            createdOn,
+            dad,
+            modifiedOn,
+            name,
+            username
+          } = snapshot.data();
 
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-
-                                        // Act
-                                        const snapshot = yield db.collection('users').orderBy('age').endAt(15).get();
-
-                                        // Assert
-                                        assert.equal(snapshot.docs.length, 2);
-                                        assert.equal(snapshot.docs[0].id, 'user_b');
-                                        assert.equal(snapshot.docs[1].id, 'user_a');
-                                });
-
-                                return function (_x28) {
-                                        return _ref28.apply(this, arguments);
-                                };
-                        })());
-
-                        QUnit.test('should error when not doing orderBy()', (() => {
-                                var _ref29 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-
-                                        try {
-                                                // Act
-                                                yield db.collection('users').endAt(15).get();
-                                        } catch (e) {
-                                                // Assert
-                                                assert.ok(true);
-                                        }
-                                });
-
-                                return function (_x29) {
-                                        return _ref29.apply(this, arguments);
-                                };
-                        })());
-                });
-
-                QUnit.module('function: endBefore', () => {
-                        QUnit.test('should return documents satisfying the query', (() => {
-                                var _ref30 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(2);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-
-                                        // Act
-                                        const snapshot = yield db.collection('users').orderBy('age').endBefore(15).get();
-
-                                        // Assert
-                                        assert.equal(snapshot.docs.length, 1);
-                                        assert.equal(snapshot.docs[0].id, 'user_b');
-                                });
-
-                                return function (_x30) {
-                                        return _ref30.apply(this, arguments);
-                                };
-                        })());
-
-                        QUnit.test('should error when not doing orderBy()', (() => {
-                                var _ref31 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-
-                                        try {
-                                                // Act
-                                                yield db.collection('users').endBefore(15).get();
-                                        } catch (e) {
-                                                // Assert
-                                                assert.ok(true);
-                                        }
-                                });
-
-                                return function (_x31) {
-                                        return _ref31.apply(this, arguments);
-                                };
-                        })());
-                });
-
-                QUnit.module('function: limit', () => {
-                        QUnit.test('should return documents satisfying the query', (() => {
-                                var _ref32 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(3);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-
-                                        // Act
-                                        const snapshot = yield db.collection('users').limit(2).get();
-
-                                        // Assert
-                                        assert.equal(snapshot.docs.length, 2);
-                                        assert.equal(snapshot.docs[0].id, 'user_a');
-                                        assert.equal(snapshot.docs[1].id, 'user_b');
-                                });
-
-                                return function (_x32) {
-                                        return _ref32.apply(this, arguments);
-                                };
-                        })());
-                });
-
-                QUnit.module('function: onSnapshot', () => {
-                        QUnit.test('should return a function for unsubscribing', assert => {
-                                assert.expect(1);
-
-                                // Arrange
-                                const db = mockFirebase.firestore();
-
-                                // Act
-                                const result = db.collection('users').orderBy('age').onSnapshot(() => {});
-
-                                // Assert
-                                assert.ok(typeof result === 'function');
-                        });
-
-                        QUnit.test('should fire callback', assert => {
-                                assert.expect(1);
-
-                                // Arrange
-                                const done = assert.async();
-                                const db = mockFirebase.firestore();
-
-                                // Act
-                                db.collection('users').orderBy('age').onSnapshot(snapshot => {
-                                        // Assert
-                                        assert.ok(snapshot instanceof _querySnapshot2.default);
-                                        done();
-                                });
-                        });
-                });
-
-                QUnit.module('function: orderBy', () => {
-                        QUnit.test('should return documents satisfying the query', (() => {
-                                var _ref33 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(3);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-
-                                        // Act
-                                        const snapshot = yield db.collection('users').orderBy('age').get();
-
-                                        // Assert
-                                        assert.equal(snapshot.docs[0].id, 'user_b');
-                                        assert.equal(snapshot.docs[1].id, 'user_a');
-                                        assert.equal(snapshot.docs[2].id, 'user_c');
-                                });
-
-                                return function (_x33) {
-                                        return _ref33.apply(this, arguments);
-                                };
-                        })());
-                });
-
-                QUnit.module('function: startAfter', () => {
-                        QUnit.test('should return documents satisfying the query', (() => {
-                                var _ref34 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(2);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-
-                                        // Act
-                                        const snapshot = yield db.collection('users').orderBy('age').startAfter(15).get();
-
-                                        // Assert
-                                        assert.equal(snapshot.docs.length, 1);
-                                        assert.equal(snapshot.docs[0].id, 'user_c');
-                                });
-
-                                return function (_x34) {
-                                        return _ref34.apply(this, arguments);
-                                };
-                        })());
-
-                        QUnit.test('should error when not doing orderBy()', (() => {
-                                var _ref35 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-
-                                        try {
-                                                // Act
-                                                yield db.collection('users').startAfter(15).get();
-                                        } catch (e) {
-                                                // Assert
-                                                assert.ok(true);
-                                        }
-                                });
-
-                                return function (_x35) {
-                                        return _ref35.apply(this, arguments);
-                                };
-                        })());
-                });
-
-                QUnit.module('function: startAt', () => {
-                        QUnit.test('should return documents satisfying the query', (() => {
-                                var _ref36 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(3);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-
-                                        // Act
-                                        const snapshot = yield db.collection('users').orderBy('age').startAt(15).get();
-
-                                        // Assert
-                                        assert.equal(snapshot.docs.length, 2);
-                                        assert.equal(snapshot.docs[0].id, 'user_a');
-                                        assert.equal(snapshot.docs[1].id, 'user_c');
-                                });
-
-                                return function (_x36) {
-                                        return _ref36.apply(this, arguments);
-                                };
-                        })());
-
-                        QUnit.test('should error when not doing orderBy()', (() => {
-                                var _ref37 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(1);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-
-                                        try {
-                                                // Act
-                                                yield db.collection('users').startAt(15).get();
-                                        } catch (e) {
-                                                // Assert
-                                                assert.ok(true);
-                                        }
-                                });
-
-                                return function (_x37) {
-                                        return _ref37.apply(this, arguments);
-                                };
-                        })());
-                });
-
-                QUnit.module('function: where', () => {
-                        QUnit.test('should return documents satisfying the query', (() => {
-                                var _ref38 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(2);
-
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-
-                                        // Act
-                                        const snapshot = yield db.collection('users').where('age', '==', 15).get();
-
-                                        // Assert
-                                        assert.equal(snapshot.docs.length, 1);
-                                        assert.equal(snapshot.docs[0].id, 'user_a');
-                                });
-
-                                return function (_x38) {
-                                        return _ref38.apply(this, arguments);
-                                };
-                        })());
-                });
+          assert.deepEqual(address, { home: 'San Francisco', work: 'Silicon Valley' });
+          assert.equal(age, 15);
+          assert.deepEqual(createdOn.toDate(), new Date('2017-01-01'));
+          assert.deepEqual(dad, db.collection('users').doc('user_b'));
+          assert.ok(modifiedOn.toDate() instanceof Date);
+          assert.equal(name, 'user_a');
+          assert.equal(username, 'user_a');
         });
 
-        QUnit.module('WriteBatch', () => {
-                QUnit.module('function: commit', () => {
-                        QUnit.test('should commit all of the writes in the write batch', (() => {
-                                var _ref39 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(7);
+        return function (_x9) {
+          return _ref9.apply(this, arguments);
+        };
+      })());
+    });
 
-                                        // Arrange
-                                        const db = mockFirebase.firestore();
-                                        const batch = db.batch();
-                                        const ref1 = db.collection('users').doc();
-                                        const ref2 = db.collection('users').doc('user_a');
-                                        const ref3 = db.collection('users').doc('user_b');
-                                        const ref4 = db.collection('users').doc('user_100');
+    QUnit.module('function: update', () => {
+      QUnit.test('should update the data', (() => {
+        var _ref10 = _asyncToGenerator(function* (assert) {
+          assert.expect(7);
 
-                                        batch.set(ref1, { username: 'new_user' });
-                                        batch.delete(ref2);
-                                        batch.update(ref3, { name: 'user-b' });
-                                        batch.set(ref4, { username: 'user_100' });
+          // Arrange
+          const db = mockFirebase.firestore();
+          const ref = db.collection('users').doc('user_a');
 
-                                        // Act
-                                        yield batch.commit();
+          // Act
+          yield ref.update({
+            dad: db.collection('users').doc('user_b'),
+            modifiedOn: _firebase2.default.firestore.FieldValue.serverTimestamp(),
+            name: 'user_a'
+          });
 
-                                        // Assert
-                                        const snapshot1 = yield ref1.get();
-                                        const snapshot2 = yield ref2.get();
-                                        const snapshot3 = yield ref3.get();
-                                        const snapshot4 = yield ref4.get();
+          // Assert
+          const snapshot = yield ref.get();
+          const {
+            address,
+            age,
+            createdOn,
+            dad,
+            modifiedOn,
+            name,
+            username
+          } = snapshot.data();
 
-                                        assert.deepEqual(snapshot1.data(), { username: 'new_user' });
-                                        assert.equal(snapshot2.exists, false);
-
-                                        const {
-                                                age: snapshot3Age,
-                                                createdOn: snapshot3CreatedOn,
-                                                name: snapshot3Name,
-                                                username: snapshot3Username
-                                        } = snapshot3.data();
-
-                                        assert.equal(snapshot3Age, 10);
-                                        assert.deepEqual(snapshot3CreatedOn.toDate(), new Date('2017-01-01'));
-                                        assert.equal(snapshot3Name, 'user-b');
-                                        assert.equal(snapshot3Username, 'user_b');
-                                        assert.deepEqual(snapshot4.data(), { username: 'user_100' });
-                                });
-
-                                return function (_x39) {
-                                        return _ref39.apply(this, arguments);
-                                };
-                        })());
-                });
+          assert.deepEqual(address, { home: 'San Francisco', work: 'Silicon Valley' });
+          assert.equal(age, 15);
+          assert.deepEqual(createdOn.toDate(), new Date('2017-01-01'));
+          assert.deepEqual(dad, db.collection('users').doc('user_b'));
+          assert.ok(modifiedOn.toDate() instanceof Date);
+          assert.equal(name, 'user_a');
+          assert.equal(username, 'user_a');
         });
+
+        return function (_x10) {
+          return _ref10.apply(this, arguments);
+        };
+      })());
+
+      QUnit.test('should throw error when updating data that does not exist', (() => {
+        var _ref11 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const ref = db.collection('users').doc('user_100');
+
+          try {
+            // Act
+            yield ref.update({ name: 'user_100' });
+          } catch (e) {
+            // Assert
+            assert.ok(true);
+          }
+        });
+
+        return function (_x11) {
+          return _ref11.apply(this, arguments);
+        };
+      })());
+    });
+  });
+
+  QUnit.module('DocumentSnapshot', () => {
+    QUnit.module('getter/setter: exists', () => {
+      QUnit.test('should return true if data exists', (() => {
+        var _ref12 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('users').doc('user_a').get();
+
+          // Act
+          const result = snapshot.exists;
+
+          // Assert
+          assert.equal(result, true);
+        });
+
+        return function (_x12) {
+          return _ref12.apply(this, arguments);
+        };
+      })());
+
+      QUnit.test('should return false if data does not exists', (() => {
+        var _ref13 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('users').doc('user_100').get();
+
+          // Act
+          const result = snapshot.exists;
+
+          // Assert
+          assert.equal(result, false);
+        });
+
+        return function (_x13) {
+          return _ref13.apply(this, arguments);
+        };
+      })());
+    });
+
+    QUnit.module('getter/setter: id', () => {
+      QUnit.test('should return the identifier', (() => {
+        var _ref14 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('users').doc('user_a').get();
+
+          // Act
+          const result = snapshot.id;
+
+          // Assert
+          assert.equal(result, 'user_a');
+        });
+
+        return function (_x14) {
+          return _ref14.apply(this, arguments);
+        };
+      })());
+    });
+
+    QUnit.module('getter/setter: ref', () => {
+      QUnit.test('should return the DocumentReference', (() => {
+        var _ref15 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('users').doc('user_a').get();
+
+          // Act
+          const result = snapshot.ref;
+
+          // Assert
+          assert.ok(result instanceof _documentReference2.default);
+        });
+
+        return function (_x15) {
+          return _ref15.apply(this, arguments);
+        };
+      })());
+    });
+
+    QUnit.module('function: get', () => {
+      QUnit.test('should return the specific field', (() => {
+        var _ref16 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('users').doc('user_a').get();
+
+          // Act
+          const result = snapshot.get('age');
+
+          // Assert
+          assert.equal(result, 15);
+        });
+
+        return function (_x16) {
+          return _ref16.apply(this, arguments);
+        };
+      })());
+
+      QUnit.test('should return the reference type field', (() => {
+        var _ref17 = _asyncToGenerator(function* (assert) {
+          assert.expect(3);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('users').doc('user_a').collection('friends').doc('user_b').get();
+
+          // Act
+          const reference = snapshot.get('reference');
+
+          // Assert
+          const referenceSnapshot = yield reference.get();
+          const { age, createdOn, username } = referenceSnapshot.data();
+
+          assert.equal(age, 10);
+          assert.deepEqual(createdOn.toDate(), new Date('2017-01-01'));
+          assert.equal(username, 'user_b');
+        });
+
+        return function (_x17) {
+          return _ref17.apply(this, arguments);
+        };
+      })());
+
+      QUnit.test('should return the specific field using dot notation', (() => {
+        var _ref18 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('users').doc('user_a').get();
+
+          // Act
+          const result = snapshot.get('address.home');
+
+          // Assert
+          assert.equal(result, 'San Francisco');
+        });
+
+        return function (_x18) {
+          return _ref18.apply(this, arguments);
+        };
+      })());
+
+      QUnit.test('should return undefined when field does not exist', (() => {
+        var _ref19 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('users').doc('user_a').get();
+
+          // Act
+          const result = snapshot.get('foobar');
+
+          // Assert
+          assert.equal(result, undefined);
+        });
+
+        return function (_x19) {
+          return _ref19.apply(this, arguments);
+        };
+      })());
+    });
+
+    QUnit.module('function: data', () => {
+      QUnit.test('should return the data', (() => {
+        var _ref20 = _asyncToGenerator(function* (assert) {
+          assert.expect(4);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('users').doc('user_a').get();
+
+          // Act
+          const {
+            address,
+            age,
+            createdOn,
+            username
+          } = snapshot.data();
+
+          // Assert
+          assert.deepEqual(address, { home: 'San Francisco', work: 'Silicon Valley' });
+          assert.equal(age, 15);
+          assert.deepEqual(createdOn.toDate(), new Date('2017-01-01'));
+          assert.equal(username, 'user_a');
+        });
+
+        return function (_x20) {
+          return _ref20.apply(this, arguments);
+        };
+      })());
+
+      QUnit.test('should flatten nested data', (() => {
+        var _ref21 = _asyncToGenerator(function* (assert) {
+          assert.expect(2);
+          // Arrange
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('users').doc('user_d').get();
+          const {
+            location,
+            family
+          } = snapshot.data();
+
+          assert.deepEqual(location, { country: 'Australia', state: 'VIC' });
+          assert.ok(family.parent instanceof _documentReference2.default);
+        });
+
+        return function (_x21) {
+          return _ref21.apply(this, arguments);
+        };
+      })());
+
+      QUnit.test('should return the data and match any reference type field appropriately', (() => {
+        var _ref22 = _asyncToGenerator(function* (assert) {
+          assert.expect(3);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('users').doc('user_a').collection('friends').doc('user_b').get();
+
+          // Act
+          const { reference } = snapshot.data();
+
+          // Assert
+          const referenceSnapshot = yield reference.get();
+          const { age, createdOn, username } = referenceSnapshot.data();
+
+          assert.equal(age, 10);
+          assert.deepEqual(createdOn.toDate(), new Date('2017-01-01'));
+          assert.equal(username, 'user_b');
+        });
+
+        return function (_x22) {
+          return _ref22.apply(this, arguments);
+        };
+      })());
+
+      QUnit.test('should return undefined when data does not exist', (() => {
+        var _ref23 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('users').doc('user_100').get();
+
+          // Act
+          const result = snapshot.data();
+
+          // Assert
+          assert.equal(result, undefined);
+        });
+
+        return function (_x23) {
+          return _ref23.apply(this, arguments);
+        };
+      })());
+    });
+  });
+
+  QUnit.module('FieldValue', () => {
+    QUnit.module('function: serverTimestamp', () => {
+      QUnit.test('should return a new date', assert => {
+        assert.expect(1);
+
+        // Act
+        const result = mockFirebase.firestore.FieldValue.serverTimestamp();
+
+        // Assert
+        assert.ok(result instanceof Date);
+      });
+    });
+  });
+
+  QUnit.module('Firestore', () => {
+    QUnit.module('static getter/setter: FieldValue', () => {
+      QUnit.test('should return an instance of FieldValue', assert => {
+        assert.expect(1);
+
+        // Act
+        const result = mockFirebase.firestore.FieldValue;
+
+        // Assert
+        assert.ok(result instanceof _fieldValue2.default);
+      });
+    });
+
+    QUnit.module('function: collection', () => {
+      QUnit.test('should return the collection reference using a path', assert => {
+        assert.expect(2);
+
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = db.doc('users/user_a/friends');
+
+        // Assert
+        assert.ok(result instanceof _collectionReference2.default);
+        assert.equal(result.id, 'friends');
+      });
+    });
+
+    QUnit.module('function: doc', () => {
+      QUnit.test('should return the document reference using a path', assert => {
+        assert.expect(2);
+
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = db.doc('users/user_a');
+
+        // Assert
+        assert.ok(result instanceof _documentReference2.default);
+        assert.equal(result.id, 'user_a');
+      });
+    });
+  });
+
+  QUnit.module('QuerySnapshot', () => {
+    QUnit.module('getter/setter: docs', () => {
+      QUnit.test('should return the documents for the query snapshot', (() => {
+        var _ref24 = _asyncToGenerator(function* (assert) {
+          assert.expect(3);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('users').get();
+
+          // Act
+          const result = snapshot.docs;
+
+          // Assert
+          assert.equal(result[0].id, 'user_a');
+          assert.equal(result[1].id, 'user_b');
+          assert.equal(result[2].id, 'user_c');
+        });
+
+        return function (_x24) {
+          return _ref24.apply(this, arguments);
+        };
+      })());
+    });
+
+    QUnit.module('getter/setter: empty', () => {
+      QUnit.test('should return true when there are no documents', (() => {
+        var _ref25 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('foobar').get();
+
+          // Act
+          const result = snapshot.empty;
+
+          // Assert
+          assert.equal(result, true);
+        });
+
+        return function (_x25) {
+          return _ref25.apply(this, arguments);
+        };
+      })());
+
+      QUnit.test('should return false when there are documents', (() => {
+        var _ref26 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('users').get();
+
+          // Act
+          const result = snapshot.empty;
+
+          // Assert
+          assert.equal(result, false);
+        });
+
+        return function (_x26) {
+          return _ref26.apply(this, arguments);
+        };
+      })());
+    });
+
+    QUnit.module('getter/setter: size', () => {
+      QUnit.test('should return the number of documents for the query snapshot', (() => {
+        var _ref27 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('users').get();
+
+          // Act
+          const result = snapshot.size;
+
+          // Assert
+          assert.equal(result, 4);
+        });
+
+        return function (_x27) {
+          return _ref27.apply(this, arguments);
+        };
+      })());
+    });
+
+    QUnit.module('function: forEach', () => {
+      QUnit.test('should fire callback per each data', (() => {
+        var _ref28 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const stub = _sinon2.default.stub();
+          const db = mockFirebase.firestore();
+          const snapshot = yield db.collection('users').get();
+
+          // Act
+          snapshot.forEach(stub);
+
+          // Assert
+          assert.equal(4, stub.callCount);
+        });
+
+        return function (_x28) {
+          return _ref28.apply(this, arguments);
+        };
+      })());
+    });
+  });
+
+  QUnit.module('Query', () => {
+    QUnit.module('getter/setter: firestore', () => {
+      QUnit.test('should return the firestore the query is in', assert => {
+        assert.expect(1);
+
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = db.collection('users').limit(1).firestore;
+
+        // Assert
+        assert.ok(result instanceof _firestore2.default);
+      });
+    });
+
+    QUnit.module('function: endAt', () => {
+      QUnit.test('should return documents satisfying the query', (() => {
+        var _ref29 = _asyncToGenerator(function* (assert) {
+          assert.expect(3);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+
+          // Act
+          const snapshot = yield db.collection('users').orderBy('age').endAt(15).get();
+
+          // Assert
+          assert.equal(snapshot.docs.length, 2);
+          assert.equal(snapshot.docs[0].id, 'user_b');
+          assert.equal(snapshot.docs[1].id, 'user_a');
+        });
+
+        return function (_x29) {
+          return _ref29.apply(this, arguments);
+        };
+      })());
+
+      QUnit.test('should error when not doing orderBy()', (() => {
+        var _ref30 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+
+          try {
+            // Act
+            yield db.collection('users').endAt(15).get();
+          } catch (e) {
+            // Assert
+            assert.ok(true);
+          }
+        });
+
+        return function (_x30) {
+          return _ref30.apply(this, arguments);
+        };
+      })());
+    });
+
+    QUnit.module('function: endBefore', () => {
+      QUnit.test('should return documents satisfying the query', (() => {
+        var _ref31 = _asyncToGenerator(function* (assert) {
+          assert.expect(2);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+
+          // Act
+          const snapshot = yield db.collection('users').orderBy('age').endBefore(15).get();
+
+          // Assert
+          assert.equal(snapshot.docs.length, 1);
+          assert.equal(snapshot.docs[0].id, 'user_b');
+        });
+
+        return function (_x31) {
+          return _ref31.apply(this, arguments);
+        };
+      })());
+
+      QUnit.test('should error when not doing orderBy()', (() => {
+        var _ref32 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+
+          try {
+            // Act
+            yield db.collection('users').endBefore(15).get();
+          } catch (e) {
+            // Assert
+            assert.ok(true);
+          }
+        });
+
+        return function (_x32) {
+          return _ref32.apply(this, arguments);
+        };
+      })());
+    });
+
+    QUnit.module('function: limit', () => {
+      QUnit.test('should return documents satisfying the query', (() => {
+        var _ref33 = _asyncToGenerator(function* (assert) {
+          assert.expect(3);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+
+          // Act
+          const snapshot = yield db.collection('users').limit(2).get();
+
+          // Assert
+          assert.equal(snapshot.docs.length, 2);
+          assert.equal(snapshot.docs[0].id, 'user_a');
+          assert.equal(snapshot.docs[1].id, 'user_b');
+        });
+
+        return function (_x33) {
+          return _ref33.apply(this, arguments);
+        };
+      })());
+    });
+
+    QUnit.module('function: onSnapshot', () => {
+      QUnit.test('should return a function for unsubscribing', assert => {
+        assert.expect(1);
+
+        // Arrange
+        const db = mockFirebase.firestore();
+
+        // Act
+        const result = db.collection('users').orderBy('age').onSnapshot(() => {});
+
+        // Assert
+        assert.ok(typeof result === 'function');
+      });
+
+      QUnit.test('should fire callback', assert => {
+        assert.expect(1);
+
+        // Arrange
+        const done = assert.async();
+        const db = mockFirebase.firestore();
+
+        // Act
+        db.collection('users').orderBy('age').onSnapshot(snapshot => {
+          // Assert
+          assert.ok(snapshot instanceof _querySnapshot2.default);
+          done();
+        });
+      });
+    });
+
+    QUnit.module('function: orderBy', () => {
+      QUnit.test('should return documents satisfying the query', (() => {
+        var _ref34 = _asyncToGenerator(function* (assert) {
+          assert.expect(3);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+
+          // Act
+          const snapshot = yield db.collection('users').orderBy('age').get();
+
+          // Assert
+          assert.equal(snapshot.docs[0].id, 'user_b');
+          assert.equal(snapshot.docs[1].id, 'user_a');
+          assert.equal(snapshot.docs[2].id, 'user_c');
+        });
+
+        return function (_x34) {
+          return _ref34.apply(this, arguments);
+        };
+      })());
+    });
+
+    QUnit.module('function: startAfter', () => {
+      QUnit.test('should return documents satisfying the query', (() => {
+        var _ref35 = _asyncToGenerator(function* (assert) {
+          assert.expect(3);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+
+          // Act
+          const snapshot = yield db.collection('users').orderBy('age').startAfter(15).get();
+
+          // Assert
+          assert.equal(snapshot.docs.length, 2);
+          assert.equal(snapshot.docs[0].id, 'user_c');
+          assert.equal(snapshot.docs[1].id, 'user_d');
+        });
+
+        return function (_x35) {
+          return _ref35.apply(this, arguments);
+        };
+      })());
+
+      QUnit.test('should error when not doing orderBy()', (() => {
+        var _ref36 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+
+          try {
+            // Act
+            yield db.collection('users').startAfter(15).get();
+          } catch (e) {
+            // Assert
+            assert.ok(true);
+          }
+        });
+
+        return function (_x36) {
+          return _ref36.apply(this, arguments);
+        };
+      })());
+    });
+
+    QUnit.module('function: startAt', () => {
+      QUnit.test('should return documents satisfying the query', (() => {
+        var _ref37 = _asyncToGenerator(function* (assert) {
+          assert.expect(4);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+
+          // Act
+          const snapshot = yield db.collection('users').orderBy('age').startAt(15).get();
+
+          // Assert
+          assert.equal(snapshot.docs.length, 3);
+          assert.equal(snapshot.docs[0].id, 'user_a');
+          assert.equal(snapshot.docs[1].id, 'user_c');
+          assert.equal(snapshot.docs[2].id, 'user_d');
+        });
+
+        return function (_x37) {
+          return _ref37.apply(this, arguments);
+        };
+      })());
+
+      QUnit.test('should error when not doing orderBy()', (() => {
+        var _ref38 = _asyncToGenerator(function* (assert) {
+          assert.expect(1);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+
+          try {
+            // Act
+            yield db.collection('users').startAt(15).get();
+          } catch (e) {
+            // Assert
+            assert.ok(true);
+          }
+        });
+
+        return function (_x38) {
+          return _ref38.apply(this, arguments);
+        };
+      })());
+    });
+
+    QUnit.module('function: where', () => {
+      QUnit.test('should return documents satisfying the query', (() => {
+        var _ref39 = _asyncToGenerator(function* (assert) {
+          assert.expect(2);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+
+          // Act
+          const snapshot = yield db.collection('users').where('age', '==', 15).get();
+
+          // Assert
+          assert.equal(snapshot.docs.length, 1);
+          assert.equal(snapshot.docs[0].id, 'user_a');
+        });
+
+        return function (_x39) {
+          return _ref39.apply(this, arguments);
+        };
+      })());
+    });
+  });
+
+  QUnit.module('WriteBatch', () => {
+    QUnit.module('function: commit', () => {
+      QUnit.test('should commit all of the writes in the write batch', (() => {
+        var _ref40 = _asyncToGenerator(function* (assert) {
+          assert.expect(7);
+
+          // Arrange
+          const db = mockFirebase.firestore();
+          const batch = db.batch();
+          const ref1 = db.collection('users').doc();
+          const ref2 = db.collection('users').doc('user_a');
+          const ref3 = db.collection('users').doc('user_b');
+          const ref4 = db.collection('users').doc('user_100');
+
+          batch.set(ref1, { username: 'new_user' });
+          batch.delete(ref2);
+          batch.update(ref3, { name: 'user-b' });
+          batch.set(ref4, { username: 'user_100' });
+
+          // Act
+          yield batch.commit();
+
+          // Assert
+          const snapshot1 = yield ref1.get();
+          const snapshot2 = yield ref2.get();
+          const snapshot3 = yield ref3.get();
+          const snapshot4 = yield ref4.get();
+
+          assert.deepEqual(snapshot1.data(), { username: 'new_user' });
+          assert.equal(snapshot2.exists, false);
+
+          const {
+            age: snapshot3Age,
+            createdOn: snapshot3CreatedOn,
+            name: snapshot3Name,
+            username: snapshot3Username
+          } = snapshot3.data();
+
+          assert.equal(snapshot3Age, 10);
+          assert.deepEqual(snapshot3CreatedOn.toDate(), new Date('2017-01-01'));
+          assert.equal(snapshot3Name, 'user-b');
+          assert.equal(snapshot3Username, 'user_b');
+          assert.deepEqual(snapshot4.data(), { username: 'user_100' });
+        });
+
+        return function (_x40) {
+          return _ref40.apply(this, arguments);
+        };
+      })());
+    });
+  });
 });

--- a/dist/node/utils/query/index.js
+++ b/dist/node/utils/query/index.js
@@ -42,8 +42,29 @@ function filterByCursor(data, prop, value, cursor) {
     return data[id][prop] >= value;
   });
 
-  for (const id of ids) {
-    filteredData[id] = data[id];
+  var _iteratorNormalCompletion = true;
+  var _didIteratorError = false;
+  var _iteratorError = undefined;
+
+  try {
+    for (var _iterator = ids[Symbol.iterator](), _step; !(_iteratorNormalCompletion = (_step = _iterator.next()).done); _iteratorNormalCompletion = true) {
+      const id = _step.value;
+
+      filteredData[id] = data[id];
+    }
+  } catch (err) {
+    _didIteratorError = true;
+    _iteratorError = err;
+  } finally {
+    try {
+      if (!_iteratorNormalCompletion && _iterator.return) {
+        _iterator.return();
+      }
+    } finally {
+      if (_didIteratorError) {
+        throw _iteratorError;
+      }
+    }
   }
 
   return filteredData;
@@ -61,8 +82,29 @@ function limit(data, threshold) {
   const filteredData = {};
   const ids = Object.keys(data).slice(0, threshold);
 
-  for (const id of ids) {
-    filteredData[id] = data[id];
+  var _iteratorNormalCompletion2 = true;
+  var _didIteratorError2 = false;
+  var _iteratorError2 = undefined;
+
+  try {
+    for (var _iterator2 = ids[Symbol.iterator](), _step2; !(_iteratorNormalCompletion2 = (_step2 = _iterator2.next()).done); _iteratorNormalCompletion2 = true) {
+      const id = _step2.value;
+
+      filteredData[id] = data[id];
+    }
+  } catch (err) {
+    _didIteratorError2 = true;
+    _iteratorError2 = err;
+  } finally {
+    try {
+      if (!_iteratorNormalCompletion2 && _iterator2.return) {
+        _iterator2.return();
+      }
+    } finally {
+      if (_didIteratorError2) {
+        throw _iteratorError2;
+      }
+    }
   }
 
   return filteredData;
@@ -100,8 +142,29 @@ function orderBy(data, key, order) {
     });
   }
 
-  for (const id of ids) {
-    filteredData[id] = data[id];
+  var _iteratorNormalCompletion3 = true;
+  var _didIteratorError3 = false;
+  var _iteratorError3 = undefined;
+
+  try {
+    for (var _iterator3 = ids[Symbol.iterator](), _step3; !(_iteratorNormalCompletion3 = (_step3 = _iterator3.next()).done); _iteratorNormalCompletion3 = true) {
+      const id = _step3.value;
+
+      filteredData[id] = data[id];
+    }
+  } catch (err) {
+    _didIteratorError3 = true;
+    _iteratorError3 = err;
+  } finally {
+    try {
+      if (!_iteratorNormalCompletion3 && _iterator3.return) {
+        _iterator3.return();
+      }
+    } finally {
+      if (_didIteratorError3) {
+        throw _iteratorError3;
+      }
+    }
   }
 
   return filteredData;
@@ -135,8 +198,29 @@ function where(data = {}, key, operator, value) {
     return data[id][key] > value;
   });
 
-  for (const id of ids) {
-    filteredData[id] = data[id];
+  var _iteratorNormalCompletion4 = true;
+  var _didIteratorError4 = false;
+  var _iteratorError4 = undefined;
+
+  try {
+    for (var _iterator4 = ids[Symbol.iterator](), _step4; !(_iteratorNormalCompletion4 = (_step4 = _iterator4.next()).done); _iteratorNormalCompletion4 = true) {
+      const id = _step4.value;
+
+      filteredData[id] = data[id];
+    }
+  } catch (err) {
+    _didIteratorError4 = true;
+    _iteratorError4 = err;
+  } finally {
+    try {
+      if (!_iteratorNormalCompletion4 && _iterator4.return) {
+        _iterator4.return();
+      }
+    } finally {
+      if (_didIteratorError4) {
+        throw _iteratorError4;
+      }
+    }
   }
 
   return filteredData;
@@ -146,14 +230,35 @@ function querySnapshot(data, collection) {
   const documentSnapshots = [];
 
   if (data && Object.prototype.hasOwnProperty.call(data, '__doc__')) {
-    for (const key of Object.keys(data.__doc__)) {
-      const documentRecord = data.__doc__[key];
+    var _iteratorNormalCompletion5 = true;
+    var _didIteratorError5 = false;
+    var _iteratorError5 = undefined;
 
-      if (!documentRecord.__isDeleted__) {
-        const documentReference = new _documentReference2.default(key, documentRecord, collection, collection.firestore);
-        const documentSnapshot = new _documentSnapshot2.default(key, documentRecord, documentReference);
+    try {
+      for (var _iterator5 = Object.keys(data.__doc__)[Symbol.iterator](), _step5; !(_iteratorNormalCompletion5 = (_step5 = _iterator5.next()).done); _iteratorNormalCompletion5 = true) {
+        const key = _step5.value;
 
-        documentSnapshots.push(documentSnapshot);
+        const documentRecord = data.__doc__[key];
+
+        if (!documentRecord.__isDeleted__) {
+          const documentReference = new _documentReference2.default(key, documentRecord, collection, collection.firestore);
+          const documentSnapshot = new _documentSnapshot2.default(key, documentRecord, documentReference);
+
+          documentSnapshots.push(documentSnapshot);
+        }
+      }
+    } catch (err) {
+      _didIteratorError5 = true;
+      _iteratorError5 = err;
+    } finally {
+      try {
+        if (!_iteratorNormalCompletion5 && _iterator5.return) {
+          _iterator5.return();
+        }
+      } finally {
+        if (_didIteratorError5) {
+          throw _iteratorError5;
+        }
       }
     }
   }

--- a/dist/node/utils/query/unit-test.js
+++ b/dist/node/utils/query/unit-test.js
@@ -402,7 +402,7 @@ QUnit.module('Unit | Util | query', () => {
   });
 
   QUnit.module('function: querySnapshot', () => {
-    QUnit.test('should return undeleted documents', assert => {
+    QUnit.test('should return QuerySnapshot of undeleted documents', assert => {
       assert.expect(1);
 
       // Arrange

--- a/dist/node/utils/test-helpers/fixture-data.js
+++ b/dist/node/utils/test-helpers/fixture-data.js
@@ -32,7 +32,6 @@ function fixtureData() {
             age: 10,
             createdOn: new Date('2017-01-01'),
             username: 'user_b',
-
             __collection__: {
               friends: {
                 __doc__: {
@@ -47,6 +46,27 @@ function fixtureData() {
             age: 20,
             createdOn: new Date('2017-01-01'),
             username: 'user_c'
+          },
+          user_d: {
+            age: 20,
+            createdOn: new Date('2017-01-01'),
+            username: 'user_b',
+            phone: [{
+              number: '04123-2345',
+              type: 'mobile'
+            }],
+            family: {
+              parent: '__ref__:users/user_a'
+            },
+            __collection__: {
+              location: {
+                __doc__: {
+                  country: 'Australia',
+                  state: 'VIC'
+                }
+              }
+            }
+
           }
         }
       }

--- a/package-lock.json
+++ b/package-lock.json
@@ -2,20 +2,12 @@
   "name": "mock-cloud-firestore",
   "version": "0.4.0",
   "lockfileVersion": 1,
-  "requires": true,
   "dependencies": {
     "@firebase/app": {
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@firebase/app/-/app-0.3.1.tgz",
       "integrity": "sha512-322IZoES5KpTYbGPXqRlqomLYQR/mgixXy9bXEYFepfno22+uxAvWxnzlw3ZHFXCCvlPAMOd+P6OWK5p2uIRqg==",
-      "dev": true,
-      "requires": {
-        "@firebase/app-types": "0.3.1",
-        "@firebase/util": "0.2.0",
-        "dom-storage": "2.1.0",
-        "tslib": "1.9.0",
-        "xmlhttprequest": "1.8.0"
-      }
+      "dev": true
     },
     "@firebase/app-types": {
       "version": "0.3.1",
@@ -27,10 +19,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@firebase/auth/-/auth-0.5.2.tgz",
       "integrity": "sha512-G2U51dEKO2jyXwOw0Ga2tQ3J2JR1gG+gajNC4ErIVhwvxdhlkewkzx+J/Thb3rjsB9z4//cw3KzPgQoqUe6UJg==",
-      "dev": true,
-      "requires": {
-        "@firebase/auth-types": "0.3.2"
-      }
+      "dev": true
     },
     "@firebase/auth-types": {
       "version": "0.3.2",
@@ -42,14 +31,7 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@firebase/database/-/database-0.3.1.tgz",
       "integrity": "sha512-XGSzie+ZIQTbaPAt7/9rLkWOhUaTFJExvWIDSzat97/3yBMxBkThfv4J8oa8KD0w+aUko7x/QNPY5R9W4b+96A==",
-      "dev": true,
-      "requires": {
-        "@firebase/database-types": "0.3.1",
-        "@firebase/logger": "0.1.1",
-        "@firebase/util": "0.2.0",
-        "faye-websocket": "0.11.1",
-        "tslib": "1.9.0"
-      }
+      "dev": true
     },
     "@firebase/database-types": {
       "version": "0.3.1",
@@ -61,14 +43,7 @@
       "version": "0.5.2",
       "resolved": "https://registry.npmjs.org/@firebase/firestore/-/firestore-0.5.2.tgz",
       "integrity": "sha512-o+wbQl2ur/8GEpxXtoKfKSHm7bNRFpnugikRpBXbcYl86nF/StXKefjedihmoU3eS107GUeuwIJJqxDGL+nDlA==",
-      "dev": true,
-      "requires": {
-        "@firebase/firestore-types": "0.4.1",
-        "@firebase/logger": "0.1.1",
-        "@firebase/webchannel-wrapper": "0.2.8",
-        "grpc": "1.10.1",
-        "tslib": "1.9.0"
-      }
+      "dev": true
     },
     "@firebase/firestore-types": {
       "version": "0.4.1",
@@ -80,12 +55,7 @@
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@firebase/functions/-/functions-0.2.2.tgz",
       "integrity": "sha512-UCIBDcF67Bd3imvA9xyrKD5TdSqpqjaaZyqJEhTAc0y6O1P1flhgnc802O7UkN+2E3aWPrlEDJh7XGY1qPMw/A==",
-      "dev": true,
-      "requires": {
-        "@firebase/functions-types": "0.1.2",
-        "@firebase/messaging-types": "0.2.2",
-        "isomorphic-fetch": "2.2.1"
-      }
+      "dev": true
     },
     "@firebase/functions-types": {
       "version": "0.1.2",
@@ -103,12 +73,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/@firebase/messaging/-/messaging-0.3.2.tgz",
       "integrity": "sha512-95u/keRrjEh0TW4KPBHLnZq/tlgBUkVLPgYalVbgJmYWCTBWspzg5+dmoHbqgabODq2nWPA8lRh/yUaEbtPN/w==",
-      "dev": true,
-      "requires": {
-        "@firebase/messaging-types": "0.2.2",
-        "@firebase/util": "0.2.0",
-        "tslib": "1.9.0"
-      }
+      "dev": true
     },
     "@firebase/messaging-types": {
       "version": "0.2.2",
@@ -120,22 +85,13 @@
       "version": "0.3.1",
       "resolved": "https://registry.npmjs.org/@firebase/polyfill/-/polyfill-0.3.1.tgz",
       "integrity": "sha512-TkmIU4OZeE+rZoQFvq9qYsHv3IYeWahvPUTknUiqN14XJ1777ZEZ+oHBM116/R/Ej3kA5EZxhahqlRHOOD/Dwg==",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.5",
-        "promise-polyfill": "7.1.2",
-        "whatwg-fetch": "2.0.4"
-      }
+      "dev": true
     },
     "@firebase/storage": {
       "version": "0.2.2",
       "resolved": "https://registry.npmjs.org/@firebase/storage/-/storage-0.2.2.tgz",
       "integrity": "sha512-zAnWDX4RfHqRRdzeKQlj37jT3ibekfsIBa6MTCYBwqtwRjf0ThnQDoySLogJi+foSrRr0pLgZHahAXJ6wZOhFQ==",
-      "dev": true,
-      "requires": {
-        "@firebase/storage-types": "0.2.2",
-        "tslib": "1.9.0"
-      }
+      "dev": true
     },
     "@firebase/storage-types": {
       "version": "0.2.2",
@@ -147,10 +103,7 @@
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/@firebase/util/-/util-0.2.0.tgz",
       "integrity": "sha512-21u60xY4ek8qmhai1s3dQM3Y+elfuIScLGz0dEthNYhiqjYOeFHs+I8MOP8cgtGBX2vYVA1OeEMwhb1mKefFlA==",
-      "dev": true,
-      "requires": {
-        "tslib": "1.9.0"
-      }
+      "dev": true
     },
     "@firebase/webchannel-wrapper": {
       "version": "0.2.8",
@@ -162,10 +115,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/@sinonjs/formatio/-/formatio-2.0.0.tgz",
       "integrity": "sha512-ls6CAMA6/5gG+O/IdsBcblvnd8qcO/l1TYoNeAzp3wcISOxlPXQEus0mLcdwazEkWjaBdaJ3TaxmNgCLWwvWzg==",
-      "dev": true,
-      "requires": {
-        "samsam": "1.3.0"
-      }
+      "dev": true
     },
     "acorn": {
       "version": "5.4.1",
@@ -178,9 +128,6 @@
       "resolved": "https://registry.npmjs.org/acorn-dynamic-import/-/acorn-dynamic-import-2.0.2.tgz",
       "integrity": "sha1-x1K9IQvvZ5UBtsbLf8hPj0cVjMQ=",
       "dev": true,
-      "requires": {
-        "acorn": "4.0.13"
-      },
       "dependencies": {
         "acorn": {
           "version": "4.0.13",
@@ -195,9 +142,6 @@
       "resolved": "https://registry.npmjs.org/acorn-jsx/-/acorn-jsx-3.0.1.tgz",
       "integrity": "sha1-r9+UiPsezvyDSPb7IvRk4ypYs2s=",
       "dev": true,
-      "requires": {
-        "acorn": "3.3.0"
-      },
       "dependencies": {
         "acorn": {
           "version": "3.3.0",
@@ -211,13 +155,7 @@
       "version": "5.5.2",
       "resolved": "https://registry.npmjs.org/ajv/-/ajv-5.5.2.tgz",
       "integrity": "sha1-c7Xuyj+rZT49P5Qis0GtQiBdyWU=",
-      "dev": true,
-      "requires": {
-        "co": "4.6.0",
-        "fast-deep-equal": "1.0.0",
-        "fast-json-stable-stringify": "2.0.0",
-        "json-schema-traverse": "0.3.1"
-      }
+      "dev": true
     },
     "ajv-keywords": {
       "version": "2.1.1",
@@ -229,21 +167,13 @@
       "version": "0.1.4",
       "resolved": "https://registry.npmjs.org/align-text/-/align-text-0.1.4.tgz",
       "integrity": "sha1-DNkKVhCT810KmSVsIrcGlDP60Rc=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2",
-        "longest": "1.0.1",
-        "repeat-string": "1.6.1"
-      }
+      "dev": true
     },
     "ansi-align": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ansi-align/-/ansi-align-2.0.0.tgz",
       "integrity": "sha1-w2rsy6VjuJzrVW82kPCx2eNUf38=",
-      "dev": true,
-      "requires": {
-        "string-width": "2.1.1"
-      }
+      "dev": true
     },
     "ansi-escapes": {
       "version": "3.0.0",
@@ -254,42 +184,30 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
-      "dev": true
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
-      "dev": true
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
     },
     "anymatch": {
       "version": "1.3.2",
       "resolved": "https://registry.npmjs.org/anymatch/-/anymatch-1.3.2.tgz",
       "integrity": "sha512-0XNayC8lTHQ2OI8aljNCN3sSx6hsr/1+rlcDAotXJR7C1oZZHCNsfpbKwMjRA3Uqb5tF1Rae2oloTr4xpq+WjA==",
-      "dev": true,
-      "requires": {
-        "micromatch": "2.3.11",
-        "normalize-path": "2.1.1"
-      }
+      "dev": true
     },
     "argparse": {
       "version": "1.0.10",
       "resolved": "https://registry.npmjs.org/argparse/-/argparse-1.0.10.tgz",
       "integrity": "sha512-o5Roy6tNG4SL/FOkCAN6RzjiakZS25RLYFrcMttJqbdd8BWrnA+fGz57iN5Pb06pvBGvl5gQ0B48dJlslXvoTg==",
-      "dev": true,
-      "requires": {
-        "sprintf-js": "1.0.3"
-      }
+      "dev": true
     },
     "arr-diff": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/arr-diff/-/arr-diff-2.0.0.tgz",
       "integrity": "sha1-jzuCf5Vai9ZpaX5KQlasPOrjVs8=",
-      "dev": true,
-      "requires": {
-        "arr-flatten": "1.1.0"
-      }
+      "dev": true
     },
     "arr-flatten": {
       "version": "1.1.0",
@@ -331,10 +249,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/array-union/-/array-union-1.0.2.tgz",
       "integrity": "sha1-mjRBDk9OPaI96jdb5b5w8kd47Dk=",
-      "dev": true,
-      "requires": {
-        "array-uniq": "1.0.3"
-      }
+      "dev": true
     },
     "array-uniq": {
       "version": "1.0.3",
@@ -358,31 +273,19 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/ascli/-/ascli-1.0.1.tgz",
       "integrity": "sha1-vPpZdKYvGOgcq660lzKrSoj5Brw=",
-      "dev": true,
-      "requires": {
-        "colour": "0.7.1",
-        "optjs": "3.2.2"
-      }
+      "dev": true
     },
     "asn1.js": {
       "version": "4.10.1",
       "resolved": "https://registry.npmjs.org/asn1.js/-/asn1.js-4.10.1.tgz",
       "integrity": "sha512-p32cOF5q0Zqs9uBiONKYLm6BClCoBCM5O9JfeUSlnQLBTxYdTK+pW+nXflm8UkKd2UYlEbYz5qEi0JuZR9ckSw==",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
-      }
+      "dev": true
     },
     "assert": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/assert/-/assert-1.4.1.tgz",
       "integrity": "sha1-mZEtWRg2tab1s0XA8H7vwI/GXZE=",
-      "dev": true,
-      "requires": {
-        "util": "0.10.3"
-      }
+      "dev": true
     },
     "assign-symbols": {
       "version": "1.0.0",
@@ -394,10 +297,7 @@
       "version": "2.6.0",
       "resolved": "https://registry.npmjs.org/async/-/async-2.6.0.tgz",
       "integrity": "sha512-xAfGg1/NTLBBKlHFmnd7PlmUW9KhVQIUuSrYem9xzFUZy13ScvtyGGejaae9iAVRiRq9+Cx7DPFaAAhCpyxyPw==",
-      "dev": true,
-      "requires": {
-        "lodash": "4.17.5"
-      }
+      "dev": true
     },
     "async-each": {
       "version": "1.0.1",
@@ -415,63 +315,27 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-cli/-/babel-cli-6.26.0.tgz",
       "integrity": "sha1-UCq1SHTX24itALiHoGODzgPQAvE=",
-      "dev": true,
-      "requires": {
-        "babel-core": "6.26.3",
-        "babel-polyfill": "6.26.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "chokidar": "1.7.0",
-        "commander": "2.12.2",
-        "convert-source-map": "1.5.1",
-        "fs-readdir-recursive": "1.1.0",
-        "glob": "7.1.2",
-        "lodash": "4.17.5",
-        "output-file-sync": "1.1.2",
-        "path-is-absolute": "1.0.1",
-        "slash": "1.0.0",
-        "source-map": "0.5.7",
-        "v8flags": "2.1.1"
-      }
+      "dev": true
     },
     "babel-code-frame": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
-      "dev": true,
-      "requires": {
-        "chalk": "1.1.3",
-        "esutils": "2.0.2",
-        "js-tokens": "3.0.2"
-      },
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
-          "dev": true,
-          "requires": {
-            "ansi-styles": "2.2.1",
-            "escape-string-regexp": "1.0.5",
-            "has-ansi": "2.0.0",
-            "strip-ansi": "3.0.1",
-            "supports-color": "2.0.0"
-          }
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
         },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
-          "dev": true
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
         }
       }
     },
@@ -479,190 +343,87 @@
       "version": "6.26.3",
       "resolved": "https://registry.npmjs.org/babel-core/-/babel-core-6.26.3.tgz",
       "integrity": "sha512-6jyFLuDmeidKmUEb3NM+/yawG0M2bDZ9Z1qbZP59cyHLz8kYGKYwpJP0UwUKKUiTRNvxfLesJnTedqczP7cTDA==",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-generator": "6.26.1",
-        "babel-helpers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-register": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "convert-source-map": "1.5.1",
-        "debug": "2.6.9",
-        "json5": "0.5.1",
-        "lodash": "4.17.5",
-        "minimatch": "3.0.4",
-        "path-is-absolute": "1.0.1",
-        "private": "0.1.8",
-        "slash": "1.0.0",
-        "source-map": "0.5.7"
-      }
+      "dev": true
     },
     "babel-generator": {
       "version": "6.26.1",
       "resolved": "https://registry.npmjs.org/babel-generator/-/babel-generator-6.26.1.tgz",
       "integrity": "sha512-HyfwY6ApZj7BYTcJURpM5tznulaBvyio7/0d4zFOeMPUmfxkCjHocCuoLa2SAGzBI8AREcH3eP3758F672DppA==",
-      "dev": true,
-      "requires": {
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "detect-indent": "4.0.0",
-        "jsesc": "1.3.0",
-        "lodash": "4.17.5",
-        "source-map": "0.5.7",
-        "trim-right": "1.0.1"
-      }
+      "dev": true
     },
     "babel-helper-builder-binary-assignment-operator-visitor": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-builder-binary-assignment-operator-visitor/-/babel-helper-builder-binary-assignment-operator-visitor-6.24.1.tgz",
       "integrity": "sha1-zORReto1b0IgvK6KAsKzRvmlZmQ=",
-      "dev": true,
-      "requires": {
-        "babel-helper-explode-assignable-expression": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "dev": true
     },
     "babel-helper-call-delegate": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-call-delegate/-/babel-helper-call-delegate-6.24.1.tgz",
       "integrity": "sha1-7Oaqzdx25Bw0YfiL/Fdb0Nqi340=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "dev": true
     },
     "babel-helper-define-map": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-define-map/-/babel-helper-define-map-6.26.0.tgz",
       "integrity": "sha1-pfVtq0GiX5fstJjH66ypgZ+Vvl8=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.5"
-      }
+      "dev": true
     },
     "babel-helper-explode-assignable-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-explode-assignable-expression/-/babel-helper-explode-assignable-expression-6.24.1.tgz",
       "integrity": "sha1-8luCz33BBDPFX3BZLVdGQArCLKo=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "dev": true
     },
     "babel-helper-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
-      "dev": true,
-      "requires": {
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk="
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0="
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-hoist-variables/-/babel-helper-hoist-variables-6.24.1.tgz",
       "integrity": "sha1-HssnaJydJVE+rbyZFKc/VAi+enY=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "dev": true
     },
     "babel-helper-optimise-call-expression": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-optimise-call-expression/-/babel-helper-optimise-call-expression-6.24.1.tgz",
       "integrity": "sha1-96E0J7qfc/j0+pk8VKl4gtEkQlc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "dev": true
     },
     "babel-helper-regex": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-helper-regex/-/babel-helper-regex-6.26.0.tgz",
       "integrity": "sha1-MlxZ+QL4LyS3T6zu0DY5VPZJXnI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.5"
-      }
+      "dev": true
     },
     "babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs="
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-replace-supers/-/babel-helper-replace-supers-6.24.1.tgz",
       "integrity": "sha1-v22/5Dk40XNpohPKiov3S2qQqxo=",
-      "dev": true,
-      "requires": {
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "dev": true
     },
     "babel-helpers": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helpers/-/babel-helpers-6.24.1.tgz",
       "integrity": "sha1-NHHenK7DiOXIUOWX5Yom3fN2ArI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
+      "dev": true
     },
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4="
     },
     "babel-plugin-add-module-exports": {
       "version": "0.2.1",
@@ -674,16 +435,12 @@
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-check-es2015-constants/-/babel-plugin-check-es2015-constants-6.22.0.tgz",
       "integrity": "sha1-NRV7EBQm/S/9PaP3XH0ekYNbv4o=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
-      "dev": true
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
@@ -700,288 +457,163 @@
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
-      "dev": true,
-      "requires": {
-        "babel-helper-remap-async-to-generator": "6.24.1",
-        "babel-plugin-syntax-async-functions": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E="
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-arrow-functions/-/babel-plugin-transform-es2015-arrow-functions-6.22.0.tgz",
       "integrity": "sha1-RSaSy3EdX3ncf4XkQM5BufJE0iE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-block-scoped-functions": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoped-functions/-/babel-plugin-transform-es2015-block-scoped-functions-6.22.0.tgz",
       "integrity": "sha1-u8UbSflk1wy42OC5ToICRs46YUE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-block-scoping": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-block-scoping/-/babel-plugin-transform-es2015-block-scoping-6.26.0.tgz",
       "integrity": "sha1-1w9SmcEwjQXBL0Y4E7CgnnOxiV8=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "lodash": "4.17.5"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-classes": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-classes/-/babel-plugin-transform-es2015-classes-6.24.1.tgz",
       "integrity": "sha1-WkxYpQyclGHlZLSyo7+ryXolhNs=",
-      "dev": true,
-      "requires": {
-        "babel-helper-define-map": "6.26.0",
-        "babel-helper-function-name": "6.24.1",
-        "babel-helper-optimise-call-expression": "6.24.1",
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-computed-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-computed-properties/-/babel-plugin-transform-es2015-computed-properties-6.24.1.tgz",
       "integrity": "sha1-b+Ko0WiV1WNPTNmZttNICjCBWbM=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-destructuring": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-destructuring/-/babel-plugin-transform-es2015-destructuring-6.23.0.tgz",
       "integrity": "sha1-mXux8auWf2gtKwh2/jWNYOdlxW0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-duplicate-keys": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-duplicate-keys/-/babel-plugin-transform-es2015-duplicate-keys-6.24.1.tgz",
       "integrity": "sha1-c+s9MQypaePvnskcU3QabxV2Qj4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-for-of": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-for-of/-/babel-plugin-transform-es2015-for-of-6.23.0.tgz",
       "integrity": "sha1-9HyVsrYT3x0+zC/bdXNiPHUkhpE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-function-name/-/babel-plugin-transform-es2015-function-name-6.24.1.tgz",
       "integrity": "sha1-g0yJhTvDaxrw86TF26qU/Y6sqos=",
-      "dev": true,
-      "requires": {
-        "babel-helper-function-name": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-literals/-/babel-plugin-transform-es2015-literals-6.22.0.tgz",
       "integrity": "sha1-T1SgLWzWbPkVKAAZox0xklN3yi4=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-modules-amd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-amd/-/babel-plugin-transform-es2015-modules-amd-6.24.1.tgz",
       "integrity": "sha1-Oz5UAXI5hC1tGcMBHEvS8AoA0VQ=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-modules-commonjs": {
       "version": "6.26.2",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-commonjs/-/babel-plugin-transform-es2015-modules-commonjs-6.26.2.tgz",
       "integrity": "sha512-CV9ROOHEdrjcwhIaJNBGMBCodN+1cfkwtM1SbUHmvyy35KGT7fohbpOxkE2uLz1o6odKK2Ck/tz47z+VqQfi9Q==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-strict-mode": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-modules-systemjs": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-systemjs/-/babel-plugin-transform-es2015-modules-systemjs-6.24.1.tgz",
       "integrity": "sha1-/4mhQrkRmpBhlfXxBuzzBdlAfSM=",
-      "dev": true,
-      "requires": {
-        "babel-helper-hoist-variables": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-modules-umd": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-modules-umd/-/babel-plugin-transform-es2015-modules-umd-6.24.1.tgz",
       "integrity": "sha1-rJl+YoXNGO1hdq22B9YCNErThGg=",
-      "dev": true,
-      "requires": {
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-object-super": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-object-super/-/babel-plugin-transform-es2015-object-super-6.24.1.tgz",
       "integrity": "sha1-JM72muIcuDp/hgPa0CH1cusnj40=",
-      "dev": true,
-      "requires": {
-        "babel-helper-replace-supers": "6.24.1",
-        "babel-runtime": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-parameters": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-parameters/-/babel-plugin-transform-es2015-parameters-6.24.1.tgz",
       "integrity": "sha1-V6w1GrScrxSpfNE7CfZv3wpiXys=",
-      "dev": true,
-      "requires": {
-        "babel-helper-call-delegate": "6.24.1",
-        "babel-helper-get-function-arity": "6.24.1",
-        "babel-runtime": "6.26.0",
-        "babel-template": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-shorthand-properties": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-shorthand-properties/-/babel-plugin-transform-es2015-shorthand-properties-6.24.1.tgz",
       "integrity": "sha1-JPh11nIch2YbvZmkYi5R8U3jiqA=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-spread": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-spread/-/babel-plugin-transform-es2015-spread-6.22.0.tgz",
       "integrity": "sha1-1taKmfia7cRTbIGlQujdnxdG+NE=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-sticky-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-sticky-regex/-/babel-plugin-transform-es2015-sticky-regex-6.24.1.tgz",
       "integrity": "sha1-AMHNsaynERLN8M9hJsLta0V8zbw=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-template-literals": {
       "version": "6.22.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-template-literals/-/babel-plugin-transform-es2015-template-literals-6.22.0.tgz",
       "integrity": "sha1-qEs0UPfp+PH2g51taH2oS7EjbY0=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-typeof-symbol": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-typeof-symbol/-/babel-plugin-transform-es2015-typeof-symbol-6.23.0.tgz",
       "integrity": "sha1-3sCfHN3/lLUqxz1QXITfWdzOs3I=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-es2015-unicode-regex": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2015-unicode-regex/-/babel-plugin-transform-es2015-unicode-regex-6.24.1.tgz",
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
-      "dev": true,
-      "requires": {
-        "babel-helper-regex": "6.26.0",
-        "babel-runtime": "6.26.0",
-        "regexpu-core": "2.0.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
       "integrity": "sha1-KrDJx/MJj6SJB3cruBP+QejeOg4=",
-      "dev": true,
-      "requires": {
-        "babel-helper-builder-binary-assignment-operator-visitor": "6.24.1",
-        "babel-plugin-syntax-exponentiation-operator": "6.13.0",
-        "babel-runtime": "6.26.0"
-      }
+      "dev": true
     },
     "babel-plugin-transform-regenerator": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-regenerator/-/babel-plugin-transform-regenerator-6.26.0.tgz",
       "integrity": "sha1-4HA2lvveJ/Cj78rPi03KL3s6jy8=",
-      "dev": true,
-      "requires": {
-        "regenerator-transform": "0.10.1"
-      }
+      "dev": true
     },
     "babel-plugin-transform-strict-mode": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-strict-mode/-/babel-plugin-transform-strict-mode-6.24.1.tgz",
       "integrity": "sha1-1fr3qleKZbvlkc9e2uBKDGcCB1g=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0"
-      }
+      "dev": true
     },
     "babel-polyfill": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-polyfill/-/babel-polyfill-6.26.0.tgz",
       "integrity": "sha1-N5k3q8Z9eJWXCtxiHyhM2WbPIVM=",
       "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
-        "regenerator-runtime": "0.10.5"
-      },
       "dependencies": {
         "regenerator-runtime": {
           "version": "0.10.5",
@@ -995,120 +627,45 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/babel-preset-env/-/babel-preset-env-1.7.0.tgz",
       "integrity": "sha512-9OR2afuKDneX2/q2EurSftUYM0xGu4O2D9adAhVfADDhrYDaxXV0rBbevVYoY9n6nyX1PmQW/0jtpJvUNr9CHg==",
-      "dev": true,
-      "requires": {
-        "babel-plugin-check-es2015-constants": "6.22.0",
-        "babel-plugin-syntax-trailing-function-commas": "6.22.0",
-        "babel-plugin-transform-async-to-generator": "6.24.1",
-        "babel-plugin-transform-es2015-arrow-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoped-functions": "6.22.0",
-        "babel-plugin-transform-es2015-block-scoping": "6.26.0",
-        "babel-plugin-transform-es2015-classes": "6.24.1",
-        "babel-plugin-transform-es2015-computed-properties": "6.24.1",
-        "babel-plugin-transform-es2015-destructuring": "6.23.0",
-        "babel-plugin-transform-es2015-duplicate-keys": "6.24.1",
-        "babel-plugin-transform-es2015-for-of": "6.23.0",
-        "babel-plugin-transform-es2015-function-name": "6.24.1",
-        "babel-plugin-transform-es2015-literals": "6.22.0",
-        "babel-plugin-transform-es2015-modules-amd": "6.24.1",
-        "babel-plugin-transform-es2015-modules-commonjs": "6.26.2",
-        "babel-plugin-transform-es2015-modules-systemjs": "6.24.1",
-        "babel-plugin-transform-es2015-modules-umd": "6.24.1",
-        "babel-plugin-transform-es2015-object-super": "6.24.1",
-        "babel-plugin-transform-es2015-parameters": "6.24.1",
-        "babel-plugin-transform-es2015-shorthand-properties": "6.24.1",
-        "babel-plugin-transform-es2015-spread": "6.22.0",
-        "babel-plugin-transform-es2015-sticky-regex": "6.24.1",
-        "babel-plugin-transform-es2015-template-literals": "6.22.0",
-        "babel-plugin-transform-es2015-typeof-symbol": "6.23.0",
-        "babel-plugin-transform-es2015-unicode-regex": "6.24.1",
-        "babel-plugin-transform-exponentiation-operator": "6.24.1",
-        "babel-plugin-transform-regenerator": "6.26.0",
-        "browserslist": "3.2.8",
-        "invariant": "2.2.4",
-        "semver": "5.5.0"
-      }
+      "dev": true
     },
     "babel-register": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-register/-/babel-register-6.26.0.tgz",
       "integrity": "sha1-btAhFz4vy0htestFxgCahW9kcHE=",
-      "dev": true,
-      "requires": {
-        "babel-core": "6.26.3",
-        "babel-runtime": "6.26.0",
-        "core-js": "2.5.5",
-        "home-or-tmp": "2.0.0",
-        "lodash": "4.17.5",
-        "mkdirp": "0.5.1",
-        "source-map-support": "0.4.18"
-      }
+      "dev": true
     },
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
-      "dev": true,
-      "requires": {
-        "core-js": "2.5.5",
-        "regenerator-runtime": "0.11.1"
-      }
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4="
     },
     "babel-template": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-traverse": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "lodash": "4.17.5"
-      }
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI="
     },
     "babel-traverse": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
-      "dev": true,
-      "requires": {
-        "babel-code-frame": "6.26.0",
-        "babel-messages": "6.23.0",
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "babylon": "6.18.0",
-        "debug": "2.6.9",
-        "globals": "9.18.0",
-        "invariant": "2.2.4",
-        "lodash": "4.17.5"
-      },
       "dependencies": {
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
-          "dev": true
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
         }
       }
     },
     "babel-types": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "esutils": "2.0.2",
-        "lodash": "4.17.5",
-        "to-fast-properties": "1.0.3"
-      }
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc="
     },
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
-      "dev": true
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -1121,15 +678,6 @@
       "resolved": "https://registry.npmjs.org/base/-/base-0.11.2.tgz",
       "integrity": "sha512-5T6P4xPgpp0YDFvSWwEZ4NoE3aM4QBQXDzmVbraCkFj8zHM+mba8SyqB5DbZWyR7mYHo6Y7BdQo3MoA4m0TeQg==",
       "dev": true,
-      "requires": {
-        "cache-base": "1.0.1",
-        "class-utils": "0.3.6",
-        "component-emitter": "1.2.1",
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "mixin-deep": "1.3.1",
-        "pascalcase": "0.1.1"
-      },
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
@@ -1168,15 +716,6 @@
       "resolved": "https://registry.npmjs.org/boxen/-/boxen-1.3.0.tgz",
       "integrity": "sha512-TNPjfTr432qx7yOjQyaXm3dSR0MH9vXp7eT1BFSl/C51g+EFnOR9hTg1IreahGBmDNCehscshe45f+C1TBZbLw==",
       "dev": true,
-      "requires": {
-        "ansi-align": "2.0.0",
-        "camelcase": "4.1.0",
-        "chalk": "2.3.1",
-        "cli-boxes": "1.0.0",
-        "string-width": "2.1.1",
-        "term-size": "1.2.0",
-        "widest-line": "2.0.0"
-      },
       "dependencies": {
         "camelcase": {
           "version": "4.1.0",
@@ -1190,22 +729,13 @@
       "version": "1.1.11",
       "resolved": "https://registry.npmjs.org/brace-expansion/-/brace-expansion-1.1.11.tgz",
       "integrity": "sha512-iCuPHDFgrHX7H2vEI/5xpz07zSHB00TpugqhmYtVmMO6518mCuRMoOYFldEBl0g187ufozdaHgWKcYFb61qGiA==",
-      "dev": true,
-      "requires": {
-        "balanced-match": "1.0.0",
-        "concat-map": "0.0.1"
-      }
+      "dev": true
     },
     "braces": {
       "version": "1.8.5",
       "resolved": "https://registry.npmjs.org/braces/-/braces-1.8.5.tgz",
       "integrity": "sha1-uneWLhLf+WnWt2cR6RS3N4V79qc=",
-      "dev": true,
-      "requires": {
-        "expand-range": "1.8.2",
-        "preserve": "0.2.0",
-        "repeat-element": "1.1.2"
-      }
+      "dev": true
     },
     "brorand": {
       "version": "1.1.0",
@@ -1217,92 +747,49 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/browserify-aes/-/browserify-aes-1.1.1.tgz",
       "integrity": "sha512-UGnTYAnB2a3YuYKIRy1/4FB2HdM866E0qC46JXvVTYKlBlZlnvfpSfY6OKfXZAkv70eJ2a1SqzpAo5CRhZGDFg==",
-      "dev": true,
-      "requires": {
-        "buffer-xor": "1.0.3",
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
-      }
+      "dev": true
     },
     "browserify-cipher": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browserify-cipher/-/browserify-cipher-1.0.0.tgz",
       "integrity": "sha1-mYgkSHS/XtTijalWZtzWasj8Njo=",
-      "dev": true,
-      "requires": {
-        "browserify-aes": "1.1.1",
-        "browserify-des": "1.0.0",
-        "evp_bytestokey": "1.0.3"
-      }
+      "dev": true
     },
     "browserify-des": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/browserify-des/-/browserify-des-1.0.0.tgz",
       "integrity": "sha1-2qJ3cXRwki7S/hhZQRihdUOXId0=",
-      "dev": true,
-      "requires": {
-        "cipher-base": "1.0.4",
-        "des.js": "1.0.0",
-        "inherits": "2.0.3"
-      }
+      "dev": true
     },
     "browserify-rsa": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/browserify-rsa/-/browserify-rsa-4.0.1.tgz",
       "integrity": "sha1-IeCr+vbyApzy+vsTNWenAdQTVSQ=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "randombytes": "2.0.6"
-      }
+      "dev": true
     },
     "browserify-sign": {
       "version": "4.0.4",
       "resolved": "https://registry.npmjs.org/browserify-sign/-/browserify-sign-4.0.4.tgz",
       "integrity": "sha1-qk62jl17ZYuqa/alfmMMvXqT0pg=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "elliptic": "6.4.0",
-        "inherits": "2.0.3",
-        "parse-asn1": "5.1.0"
-      }
+      "dev": true
     },
     "browserify-zlib": {
       "version": "0.2.0",
       "resolved": "https://registry.npmjs.org/browserify-zlib/-/browserify-zlib-0.2.0.tgz",
       "integrity": "sha512-Z942RysHXmJrhqk88FmKBVq/v5tqmSkDz7p54G/MGyjMnCFFnC79XWNbg+Vta8W6Wb2qtSZTSxIGkJrRpCFEiA==",
-      "dev": true,
-      "requires": {
-        "pako": "1.0.6"
-      }
+      "dev": true
     },
     "browserslist": {
       "version": "3.2.8",
       "resolved": "https://registry.npmjs.org/browserslist/-/browserslist-3.2.8.tgz",
       "integrity": "sha512-WHVocJYavUwVgVViC0ORikPHQquXwVh939TaelZ4WDqpWgTX/FsGhl/+P4qBUAGcRvtOgDgC+xftNWWp2RUTAQ==",
-      "dev": true,
-      "requires": {
-        "caniuse-lite": "1.0.30000846",
-        "electron-to-chromium": "1.3.48"
-      }
+      "dev": true
     },
     "buffer": {
       "version": "4.9.1",
       "resolved": "https://registry.npmjs.org/buffer/-/buffer-4.9.1.tgz",
       "integrity": "sha1-bRu2AbB6TvztlwlBMgkwJ8lbwpg=",
-      "dev": true,
-      "requires": {
-        "base64-js": "1.2.3",
-        "ieee754": "1.1.8",
-        "isarray": "1.0.0"
-      }
+      "dev": true
     },
     "buffer-xor": {
       "version": "1.0.3",
@@ -1326,27 +813,13 @@
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/bytebuffer/-/bytebuffer-5.0.1.tgz",
       "integrity": "sha1-WC7qSxqHO20CCkjVjfhfC7ps/d0=",
-      "dev": true,
-      "requires": {
-        "long": "3.2.0"
-      }
+      "dev": true
     },
     "cache-base": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/cache-base/-/cache-base-1.0.1.tgz",
       "integrity": "sha512-AKcdTnFSWATd5/GCPRxr2ChwIJ85CeyrEyjRHlKxQ56d4XJMGym0uAiKn0xbLOGOl3+yRpOTi484dVCEc5AUzQ==",
       "dev": true,
-      "requires": {
-        "collection-visit": "1.0.0",
-        "component-emitter": "1.2.1",
-        "get-value": "2.0.6",
-        "has-value": "1.0.0",
-        "isobject": "3.0.1",
-        "set-value": "2.0.0",
-        "to-object-path": "0.3.0",
-        "union-value": "1.0.0",
-        "unset-value": "1.0.0"
-      },
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
@@ -1360,10 +833,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/caller-path/-/caller-path-0.1.0.tgz",
       "integrity": "sha1-lAhe9jWB7NPaqSREqP6U6CV3dR8=",
-      "dev": true,
-      "requires": {
-        "callsites": "0.2.0"
-      }
+      "dev": true
     },
     "callsites": {
       "version": "0.2.0",
@@ -1382,10 +852,6 @@
       "resolved": "https://registry.npmjs.org/camelcase-keys/-/camelcase-keys-2.1.0.tgz",
       "integrity": "sha1-MIvur/3ygRkFHvodkyITyRuPkuc=",
       "dev": true,
-      "requires": {
-        "camelcase": "2.1.1",
-        "map-obj": "1.0.1"
-      },
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
@@ -1412,10 +878,6 @@
       "resolved": "https://registry.npmjs.org/center-align/-/center-align-0.1.3.tgz",
       "integrity": "sha1-qg0yYptu6XIgBBHL1EYckHvCt60=",
       "dev": true,
-      "requires": {
-        "align-text": "0.1.4",
-        "lazy-cache": "1.0.4"
-      },
       "dependencies": {
         "lazy-cache": {
           "version": "1.0.4",
@@ -1430,20 +892,12 @@
       "resolved": "https://registry.npmjs.org/chalk/-/chalk-2.3.1.tgz",
       "integrity": "sha512-QUU4ofkDoMIVO7hcx1iPTISs88wsO8jA92RQIm4JAwZvFGGAV2hSAA1NX7oVj2Ej2Q6NDTcRDjPTFrMCRZoJ6g==",
       "dev": true,
-      "requires": {
-        "ansi-styles": "3.2.0",
-        "escape-string-regexp": "1.0.5",
-        "supports-color": "5.2.0"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         }
       }
     },
@@ -1457,18 +911,7 @@
       "version": "1.7.0",
       "resolved": "https://registry.npmjs.org/chokidar/-/chokidar-1.7.0.tgz",
       "integrity": "sha1-eY5ol3gVHIB2tLNg5e3SjNortGg=",
-      "dev": true,
-      "requires": {
-        "anymatch": "1.3.2",
-        "async-each": "1.0.1",
-        "fsevents": "1.1.3",
-        "glob-parent": "2.0.0",
-        "inherits": "2.0.3",
-        "is-binary-path": "1.0.1",
-        "is-glob": "2.0.1",
-        "path-is-absolute": "1.0.1",
-        "readdirp": "2.1.0"
-      }
+      "dev": true
     },
     "ci-info": {
       "version": "1.1.3",
@@ -1480,11 +923,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/cipher-base/-/cipher-base-1.0.4.tgz",
       "integrity": "sha512-Kkht5ye6ZGmwv40uUDZztayT2ThLQGfnj/T71N/XzeZeo3nf8foyW7zGTsPYkEya3m5f3cAypH+qe7YOrM1U2Q==",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
-      }
+      "dev": true
     },
     "circular-json": {
       "version": "0.3.3",
@@ -1497,39 +936,24 @@
       "resolved": "https://registry.npmjs.org/class-utils/-/class-utils-0.3.6.tgz",
       "integrity": "sha512-qOhPa/Fj7s6TY8H8esGu5QNpMMQxz79h+urzrNYN6mn+9BnxlDGf5QZ+XeCDsxSjPqsSR56XOZOJmpeurnLMeg==",
       "dev": true,
-      "requires": {
-        "arr-union": "3.1.0",
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "static-extend": "0.1.2"
-      },
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
+          "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "dev": true
             }
           }
         },
@@ -1538,18 +962,12 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "dev": true
             }
           }
         },
@@ -1557,12 +975,7 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
+          "dev": true
         },
         "isobject": {
           "version": "3.0.1",
@@ -1588,10 +1001,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/cli-cursor/-/cli-cursor-2.1.0.tgz",
       "integrity": "sha1-s12sN2R5+sw+lHR9QdDQ9SOP/LU=",
-      "dev": true,
-      "requires": {
-        "restore-cursor": "2.0.0"
-      }
+      "dev": true
     },
     "cli-width": {
       "version": "2.2.0",
@@ -1604,11 +1014,6 @@
       "resolved": "https://registry.npmjs.org/cliui/-/cliui-2.1.0.tgz",
       "integrity": "sha1-S0dXYP+AJkx2LDoXGQMukcf+oNE=",
       "dev": true,
-      "requires": {
-        "center-align": "0.1.3",
-        "right-align": "0.1.3",
-        "wordwrap": "0.0.2"
-      },
       "dependencies": {
         "wordwrap": {
           "version": "0.0.2",
@@ -1634,20 +1039,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/collection-visit/-/collection-visit-1.0.0.tgz",
       "integrity": "sha1-S8A3PBZLwykbTTaMgpzxqApZ3KA=",
-      "dev": true,
-      "requires": {
-        "map-visit": "1.0.0",
-        "object-visit": "1.0.1"
-      }
+      "dev": true
     },
     "color-convert": {
       "version": "1.9.1",
       "resolved": "https://registry.npmjs.org/color-convert/-/color-convert-1.9.1.tgz",
       "integrity": "sha512-mjGanIiwQJskCC18rPR6OmrZ6fm2Lc7PeGFYwCmy5J34wC6F1PzdGL6xeMfmgicfYcNLGuVFA3WzXtIDCQSZxQ==",
-      "dev": true,
-      "requires": {
-        "color-name": "1.1.3"
-      }
+      "dev": true
     },
     "color-name": {
       "version": "1.1.3",
@@ -1683,35 +1081,19 @@
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/concat-stream/-/concat-stream-1.6.0.tgz",
       "integrity": "sha1-CqxmL9Ur54lk1VMvaUeE5wEQrPc=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4",
-        "typedarray": "0.0.6"
-      }
+      "dev": true
     },
     "configstore": {
       "version": "3.1.2",
       "resolved": "https://registry.npmjs.org/configstore/-/configstore-3.1.2.tgz",
       "integrity": "sha512-vtv5HtGjcYUgFrXc6Kx747B83MRRVS5R1VTEQoXvuP+kMI+if6uywV0nDGoiydJRy4yk7h9od5Og0kxx4zUXmw==",
-      "dev": true,
-      "requires": {
-        "dot-prop": "4.2.0",
-        "graceful-fs": "4.1.11",
-        "make-dir": "1.3.0",
-        "unique-string": "1.0.0",
-        "write-file-atomic": "2.3.0",
-        "xdg-basedir": "3.0.0"
-      }
+      "dev": true
     },
     "console-browserify": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/console-browserify/-/console-browserify-1.1.0.tgz",
       "integrity": "sha1-8CQcRXMKn8YyOyBtvzjtx0HQuxA=",
-      "dev": true,
-      "requires": {
-        "date-now": "0.1.4"
-      }
+      "dev": true
     },
     "constants-browserify": {
       "version": "1.0.0",
@@ -1740,8 +1122,7 @@
     "core-js": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
-      "dev": true
+      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1753,76 +1134,37 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/create-ecdh/-/create-ecdh-4.0.0.tgz",
       "integrity": "sha1-iIxyNZbN92EvZJgjPuvXo1MBc30=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "elliptic": "6.4.0"
-      }
+      "dev": true
     },
     "create-error-class": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/create-error-class/-/create-error-class-3.0.2.tgz",
       "integrity": "sha1-Br56vvlHo/FKMP1hBnHUAbyot7Y=",
-      "dev": true,
-      "requires": {
-        "capture-stack-trace": "1.0.0"
-      }
+      "dev": true
     },
     "create-hash": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/create-hash/-/create-hash-1.1.3.tgz",
       "integrity": "sha1-YGBCrIuSYnUPSDyt2rD1gZFy2P0=",
-      "dev": true,
-      "requires": {
-        "cipher-base": "1.0.4",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "sha.js": "2.4.10"
-      }
+      "dev": true
     },
     "create-hmac": {
       "version": "1.1.6",
       "resolved": "https://registry.npmjs.org/create-hmac/-/create-hmac-1.1.6.tgz",
       "integrity": "sha1-rLniIaThe9sHbpBlfEK5PjcmzwY=",
-      "dev": true,
-      "requires": {
-        "cipher-base": "1.0.4",
-        "create-hash": "1.1.3",
-        "inherits": "2.0.3",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
-      }
+      "dev": true
     },
     "cross-spawn": {
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/cross-spawn/-/cross-spawn-5.1.0.tgz",
       "integrity": "sha1-6L0O/uWPz/b4+UUQoKVUu/ojVEk=",
-      "dev": true,
-      "requires": {
-        "lru-cache": "4.1.1",
-        "shebang-command": "1.2.0",
-        "which": "1.3.0"
-      }
+      "dev": true
     },
     "crypto-browserify": {
       "version": "3.12.0",
       "resolved": "https://registry.npmjs.org/crypto-browserify/-/crypto-browserify-3.12.0.tgz",
       "integrity": "sha512-fz4spIh+znjO2VjL+IdhEpRJ3YN6sMzITSBijk6FK2UvTqruSQW+/cCZTSNsMiZNvUeq0CqurF+dAbyiGOY6Wg==",
-      "dev": true,
-      "requires": {
-        "browserify-cipher": "1.0.0",
-        "browserify-sign": "4.0.4",
-        "create-ecdh": "4.0.0",
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "diffie-hellman": "5.0.2",
-        "inherits": "2.0.3",
-        "pbkdf2": "3.0.14",
-        "public-encrypt": "4.0.0",
-        "randombytes": "2.0.6",
-        "randomfill": "1.0.4"
-      }
+      "dev": true
     },
     "crypto-random-string": {
       "version": "1.0.0",
@@ -1834,19 +1176,13 @@
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/currently-unhandled/-/currently-unhandled-0.4.1.tgz",
       "integrity": "sha1-mI3zP+qxke95mmE2nddsF635V+o=",
-      "dev": true,
-      "requires": {
-        "array-find-index": "1.0.2"
-      }
+      "dev": true
     },
     "d": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/d/-/d-1.0.0.tgz",
       "integrity": "sha1-dUu1v+VUUdpppYuU1F9MWwRi1Y8=",
-      "dev": true,
-      "requires": {
-        "es5-ext": "0.10.39"
-      }
+      "dev": true
     },
     "date-now": {
       "version": "0.1.4",
@@ -1857,11 +1193,7 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
-      "dev": true,
-      "requires": {
-        "ms": "2.0.0"
-      }
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
     },
     "decamelize": {
       "version": "1.2.0",
@@ -1891,73 +1223,37 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/define-properties/-/define-properties-1.1.2.tgz",
       "integrity": "sha1-g6c/L+pWmJj7c3GTyPhzyvbUXJQ=",
-      "dev": true,
-      "requires": {
-        "foreach": "2.0.5",
-        "object-keys": "1.0.11"
-      }
+      "dev": true
     },
     "define-property": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/define-property/-/define-property-1.0.0.tgz",
       "integrity": "sha1-dp66rz9KY6rTr56NMEybvnm/sOY=",
-      "dev": true,
-      "requires": {
-        "is-descriptor": "1.0.2"
-      }
+      "dev": true
     },
     "del": {
       "version": "2.2.2",
       "resolved": "https://registry.npmjs.org/del/-/del-2.2.2.tgz",
       "integrity": "sha1-wSyYHQZ4RshLyvhiz/kw2Qf/0ag=",
-      "dev": true,
-      "requires": {
-        "globby": "5.0.0",
-        "is-path-cwd": "1.0.0",
-        "is-path-in-cwd": "1.0.0",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1",
-        "rimraf": "2.6.2"
-      }
+      "dev": true
     },
     "del-cli": {
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/del-cli/-/del-cli-1.1.0.tgz",
       "integrity": "sha1-J1V9aaC335ncuqHjSgnmrGWR0sQ=",
       "dev": true,
-      "requires": {
-        "del": "3.0.0",
-        "meow": "3.7.0",
-        "update-notifier": "2.5.0"
-      },
       "dependencies": {
         "del": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/del/-/del-3.0.0.tgz",
           "integrity": "sha1-U+z2mf/LyzljdpGrE7rxYIGXZuU=",
-          "dev": true,
-          "requires": {
-            "globby": "6.1.0",
-            "is-path-cwd": "1.0.0",
-            "is-path-in-cwd": "1.0.0",
-            "p-map": "1.2.0",
-            "pify": "3.0.0",
-            "rimraf": "2.6.2"
-          }
+          "dev": true
         },
         "globby": {
           "version": "6.1.0",
           "resolved": "https://registry.npmjs.org/globby/-/globby-6.1.0.tgz",
           "integrity": "sha1-9abXDoOV4hyFj7BInWTfAkJNUGw=",
           "dev": true,
-          "requires": {
-            "array-union": "1.0.2",
-            "glob": "7.1.2",
-            "object-assign": "4.1.1",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          },
           "dependencies": {
             "pify": {
               "version": "2.3.0",
@@ -1979,11 +1275,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/des.js/-/des.js-1.0.0.tgz",
       "integrity": "sha1-wHTS4qpqipoH29YfmhXCzYPsjsw=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
-      }
+      "dev": true
     },
     "detect-file": {
       "version": "1.0.0",
@@ -1995,10 +1287,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/detect-indent/-/detect-indent-4.0.0.tgz",
       "integrity": "sha1-920GQ1LN9Docts5hnE7jqUdd4gg=",
-      "dev": true,
-      "requires": {
-        "repeating": "2.0.1"
-      }
+      "dev": true
     },
     "diff": {
       "version": "3.4.0",
@@ -2010,21 +1299,13 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/diffie-hellman/-/diffie-hellman-5.0.2.tgz",
       "integrity": "sha1-tYNXOScM/ias9jIJn97SoH8gnl4=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "miller-rabin": "4.0.1",
-        "randombytes": "2.0.6"
-      }
+      "dev": true
     },
     "doctrine": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-2.1.0.tgz",
       "integrity": "sha512-35mSku4ZXK0vfCuHEDAwt55dg2jNajHZ1odvF+8SSr82EsZY4QmXfuWso8oEd8zRhVObSN18aM0CjSdoBX7zIw==",
-      "dev": true,
-      "requires": {
-        "esutils": "2.0.2"
-      }
+      "dev": true
     },
     "dom-storage": {
       "version": "2.1.0",
@@ -2042,10 +1323,7 @@
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/dot-prop/-/dot-prop-4.2.0.tgz",
       "integrity": "sha512-tUMXrxlExSW6U2EXiiKGSBVdYgtV8qlHL+C10TsW4PURY/ic+eaysnSkwB4kA/mBlCyy/IKDJ+Lc3wbWeaXtuQ==",
-      "dev": true,
-      "requires": {
-        "is-obj": "1.0.1"
-      }
+      "dev": true
     },
     "duplexer": {
       "version": "0.1.1",
@@ -2069,16 +1347,7 @@
       "version": "6.4.0",
       "resolved": "https://registry.npmjs.org/elliptic/-/elliptic-6.4.0.tgz",
       "integrity": "sha1-ysmvh2LIWDYYcAPI3+GT5eLq5d8=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0",
-        "hash.js": "1.1.3",
-        "hmac-drbg": "1.0.1",
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
-      }
+      "dev": true
     },
     "emojis-list": {
       "version": "2.1.0",
@@ -2090,22 +1359,13 @@
       "version": "0.1.12",
       "resolved": "https://registry.npmjs.org/encoding/-/encoding-0.1.12.tgz",
       "integrity": "sha1-U4tm8+5izRq1HsMjgp0flIDHS+s=",
-      "dev": true,
-      "requires": {
-        "iconv-lite": "0.4.19"
-      }
+      "dev": true
     },
     "enhanced-resolve": {
       "version": "3.4.1",
       "resolved": "https://registry.npmjs.org/enhanced-resolve/-/enhanced-resolve-3.4.1.tgz",
       "integrity": "sha1-BCHjOf1xQZs9oT0Smzl5BAIwR24=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "memory-fs": "0.4.1",
-        "object-assign": "4.1.1",
-        "tapable": "0.2.8"
-      }
+      "dev": true
     },
     "ensure-posix-path": {
       "version": "1.0.2",
@@ -2117,185 +1377,84 @@
       "version": "0.1.7",
       "resolved": "https://registry.npmjs.org/errno/-/errno-0.1.7.tgz",
       "integrity": "sha512-MfrRBDWzIWifgq6tJj60gkAwtLNb6sQPlcFrSOflcP1aFmmruKQ2wRnze/8V6kgyz7H3FF8Npzv78mZ7XLLflg==",
-      "dev": true,
-      "requires": {
-        "prr": "1.0.1"
-      }
+      "dev": true
     },
     "error-ex": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/error-ex/-/error-ex-1.3.1.tgz",
       "integrity": "sha1-+FWobOYa3E6GIcPNoh56dhLDqNw=",
-      "dev": true,
-      "requires": {
-        "is-arrayish": "0.2.1"
-      }
+      "dev": true
     },
     "es-abstract": {
       "version": "1.10.0",
       "resolved": "https://registry.npmjs.org/es-abstract/-/es-abstract-1.10.0.tgz",
       "integrity": "sha512-/uh/DhdqIOSkAWifU+8nG78vlQxdLckUdI/sPgy0VhuXi2qJ7T8czBmqIYtLQVpCIFYafChnsRsB5pyb1JdmCQ==",
-      "dev": true,
-      "requires": {
-        "es-to-primitive": "1.1.1",
-        "function-bind": "1.1.1",
-        "has": "1.0.1",
-        "is-callable": "1.1.3",
-        "is-regex": "1.0.4"
-      }
+      "dev": true
     },
     "es-to-primitive": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/es-to-primitive/-/es-to-primitive-1.1.1.tgz",
       "integrity": "sha1-RTVSSKiJeQNLZ5Lhm7gfK3l13Q0=",
-      "dev": true,
-      "requires": {
-        "is-callable": "1.1.3",
-        "is-date-object": "1.0.1",
-        "is-symbol": "1.0.1"
-      }
+      "dev": true
     },
     "es5-ext": {
       "version": "0.10.39",
       "resolved": "https://registry.npmjs.org/es5-ext/-/es5-ext-0.10.39.tgz",
       "integrity": "sha512-AlaXZhPHl0po/uxMx1tyrlt1O86M6D5iVaDH8UgLfgek4kXTX6vzsRfJQWC2Ku+aG8pkw1XWzh9eTkwfVrsD5g==",
-      "dev": true,
-      "requires": {
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
-      }
+      "dev": true
     },
     "es6-iterator": {
       "version": "2.0.3",
       "resolved": "https://registry.npmjs.org/es6-iterator/-/es6-iterator-2.0.3.tgz",
       "integrity": "sha1-p96IkUGgWpSwhUQDstCg+/qY87c=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39",
-        "es6-symbol": "3.1.1"
-      }
+      "dev": true
     },
     "es6-map": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-map/-/es6-map-0.1.5.tgz",
       "integrity": "sha1-kTbgUD3MBqMBaQ8LsU/042TpSfA=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39",
-        "es6-iterator": "2.0.3",
-        "es6-set": "0.1.5",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
-      }
+      "dev": true
     },
     "es6-set": {
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/es6-set/-/es6-set-0.1.5.tgz",
       "integrity": "sha1-0rPsXU2ADO2BjbU40ol02wpzzLE=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1",
-        "event-emitter": "0.3.5"
-      }
+      "dev": true
     },
     "es6-symbol": {
       "version": "3.1.1",
       "resolved": "https://registry.npmjs.org/es6-symbol/-/es6-symbol-3.1.1.tgz",
       "integrity": "sha1-vwDvT9q2uhtG7Le2KbTH7VcVzHc=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39"
-      }
+      "dev": true
     },
     "es6-weak-map": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/es6-weak-map/-/es6-weak-map-2.0.2.tgz",
       "integrity": "sha1-XjqzIlH/0VOKH45f+hNXdy+S2W8=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39",
-        "es6-iterator": "2.0.3",
-        "es6-symbol": "3.1.1"
-      }
+      "dev": true
     },
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
-      "dev": true
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
     },
     "escope": {
       "version": "3.6.0",
       "resolved": "https://registry.npmjs.org/escope/-/escope-3.6.0.tgz",
       "integrity": "sha1-4Bl16BJ4GhY6ba392AOY3GTIicM=",
-      "dev": true,
-      "requires": {
-        "es6-map": "0.1.5",
-        "es6-weak-map": "2.0.2",
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
-      }
+      "dev": true
     },
     "eslint": {
       "version": "4.17.0",
       "resolved": "https://registry.npmjs.org/eslint/-/eslint-4.17.0.tgz",
       "integrity": "sha512-AyxBUCANU/o/xC0ijGMKavo5Ls3oK6xykiOITlMdjFjrKOsqLrA7Nf5cnrDgcKrHzBirclAZt63XO7YZlVUPwA==",
       "dev": true,
-      "requires": {
-        "ajv": "5.5.2",
-        "babel-code-frame": "6.26.0",
-        "chalk": "2.3.1",
-        "concat-stream": "1.6.0",
-        "cross-spawn": "5.1.0",
-        "debug": "3.1.0",
-        "doctrine": "2.1.0",
-        "eslint-scope": "3.7.1",
-        "eslint-visitor-keys": "1.0.0",
-        "espree": "3.5.3",
-        "esquery": "1.0.0",
-        "esutils": "2.0.2",
-        "file-entry-cache": "2.0.0",
-        "functional-red-black-tree": "1.0.1",
-        "glob": "7.1.2",
-        "globals": "11.3.0",
-        "ignore": "3.3.7",
-        "imurmurhash": "0.1.4",
-        "inquirer": "3.3.0",
-        "is-resolvable": "1.1.0",
-        "js-yaml": "3.10.0",
-        "json-stable-stringify-without-jsonify": "1.0.1",
-        "levn": "0.3.0",
-        "lodash": "4.17.5",
-        "minimatch": "3.0.4",
-        "mkdirp": "0.5.1",
-        "natural-compare": "1.4.0",
-        "optionator": "0.8.2",
-        "path-is-inside": "1.0.2",
-        "pluralize": "7.0.0",
-        "progress": "2.0.0",
-        "require-uncached": "1.0.3",
-        "semver": "5.5.0",
-        "strip-ansi": "4.0.0",
-        "strip-json-comments": "2.0.1",
-        "table": "4.0.2",
-        "text-table": "0.2.0"
-      },
       "dependencies": {
         "debug": {
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/debug/-/debug-3.1.0.tgz",
           "integrity": "sha512-OX8XqP7/1a9cqkxYw2yXss15f26NKWBpDXQd0/uK/KPqdQhxbPa994hnzjcE2VqQpDslf55723cKPUOGSmMY3g==",
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -2303,10 +1462,7 @@
       "version": "12.1.0",
       "resolved": "https://registry.npmjs.org/eslint-config-airbnb-base/-/eslint-config-airbnb-base-12.1.0.tgz",
       "integrity": "sha512-/vjm0Px5ZCpmJqnjIzcFb9TKZrKWz0gnuG/7Gfkt0Db1ELJR51xkZth+t14rYdqWgX836XbuxtArbIHlVhbLBA==",
-      "dev": true,
-      "requires": {
-        "eslint-restricted-globals": "0.1.1"
-      }
+      "dev": true
     },
     "eslint-config-rmmmp": {
       "version": "0.2.2",
@@ -2318,49 +1474,25 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/eslint-import-resolver-node/-/eslint-import-resolver-node-0.3.2.tgz",
       "integrity": "sha512-sfmTqJfPSizWu4aymbPr4Iidp5yKm8yDkHp+Ir3YiTHiiDfxh69mOUsmiqW6RZ9zRXFaF64GtYmN7e+8GHBv6Q==",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "resolve": "1.5.0"
-      }
+      "dev": true
     },
     "eslint-module-utils": {
       "version": "2.2.0",
       "resolved": "https://registry.npmjs.org/eslint-module-utils/-/eslint-module-utils-2.2.0.tgz",
       "integrity": "sha1-snA2LNiLGkitMIl2zn+lTphBF0Y=",
-      "dev": true,
-      "requires": {
-        "debug": "2.6.9",
-        "pkg-dir": "1.0.0"
-      }
+      "dev": true
     },
     "eslint-plugin-import": {
       "version": "2.7.0",
       "resolved": "https://registry.npmjs.org/eslint-plugin-import/-/eslint-plugin-import-2.7.0.tgz",
       "integrity": "sha512-HGYmpU9f/zJaQiKNQOVfHUh2oLWW3STBrCgH0sHTX1xtsxYlH1zjLh8FlQGEIdZSdTbUMaV36WaZ6ImXkenGxQ==",
       "dev": true,
-      "requires": {
-        "builtin-modules": "1.1.1",
-        "contains-path": "0.1.0",
-        "debug": "2.6.9",
-        "doctrine": "1.5.0",
-        "eslint-import-resolver-node": "0.3.2",
-        "eslint-module-utils": "2.2.0",
-        "has": "1.0.1",
-        "lodash.cond": "4.5.2",
-        "minimatch": "3.0.4",
-        "read-pkg-up": "2.0.0"
-      },
       "dependencies": {
         "doctrine": {
           "version": "1.5.0",
           "resolved": "https://registry.npmjs.org/doctrine/-/doctrine-1.5.0.tgz",
           "integrity": "sha1-N53Ocw9hZvds76TmcHoVmwLFpvo=",
-          "dev": true,
-          "requires": {
-            "esutils": "2.0.2",
-            "isarray": "1.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -2374,11 +1506,7 @@
       "version": "3.7.1",
       "resolved": "https://registry.npmjs.org/eslint-scope/-/eslint-scope-3.7.1.tgz",
       "integrity": "sha1-PWPD7f2gLgbgGkUq2IyqzHzctug=",
-      "dev": true,
-      "requires": {
-        "esrecurse": "4.2.0",
-        "estraverse": "4.2.0"
-      }
+      "dev": true
     },
     "eslint-visitor-keys": {
       "version": "1.0.0",
@@ -2390,11 +1518,7 @@
       "version": "3.5.3",
       "resolved": "https://registry.npmjs.org/espree/-/espree-3.5.3.tgz",
       "integrity": "sha512-Zy3tAJDORxQZLl2baguiRU1syPERAIg0L+JB2MWorORgTu/CplzvxS9WWA7Xh4+Q+eOQihNs/1o1Xep8cvCxWQ==",
-      "dev": true,
-      "requires": {
-        "acorn": "5.4.1",
-        "acorn-jsx": "3.0.1"
-      }
+      "dev": true
     },
     "esprima": {
       "version": "4.0.0",
@@ -2406,20 +1530,13 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/esquery/-/esquery-1.0.0.tgz",
       "integrity": "sha1-z7qLV9f7qT8XKYqKAGoEzaE9gPo=",
-      "dev": true,
-      "requires": {
-        "estraverse": "4.2.0"
-      }
+      "dev": true
     },
     "esrecurse": {
       "version": "4.2.0",
       "resolved": "https://registry.npmjs.org/esrecurse/-/esrecurse-4.2.0.tgz",
       "integrity": "sha1-+pVo2Y04I/mkHZHpAtyrnqblsWM=",
-      "dev": true,
-      "requires": {
-        "estraverse": "4.2.0",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "estraverse": {
       "version": "4.2.0",
@@ -2430,33 +1547,19 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
-      "dev": true
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
     },
     "event-emitter": {
       "version": "0.3.5",
       "resolved": "https://registry.npmjs.org/event-emitter/-/event-emitter-0.3.5.tgz",
       "integrity": "sha1-34xp7vFkeSPHFXuc6DhAYQsCzDk=",
-      "dev": true,
-      "requires": {
-        "d": "1.0.0",
-        "es5-ext": "0.10.39"
-      }
+      "dev": true
     },
     "event-stream": {
       "version": "3.3.4",
-      "resolved": "https://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
+      "resolved": "http://registry.npmjs.org/event-stream/-/event-stream-3.3.4.tgz",
       "integrity": "sha1-SrTJoPWlTbkzi0w02Gv86PSzVXE=",
-      "dev": true,
-      "requires": {
-        "duplexer": "0.1.1",
-        "from": "0.1.7",
-        "map-stream": "0.1.0",
-        "pause-stream": "0.0.11",
-        "split": "0.3.3",
-        "stream-combiner": "0.0.4",
-        "through": "2.3.8"
-      }
+      "dev": true
     },
     "events": {
       "version": "1.1.1",
@@ -2468,26 +1571,13 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/evp_bytestokey/-/evp_bytestokey-1.0.3.tgz",
       "integrity": "sha512-/f2Go4TognH/KvCISP7OUsHn85hT9nUkxxA9BEWxFn+Oj9o8ZNLm/40hdlgSLyuOimsrTKLUMEorQexp/aPQeA==",
-      "dev": true,
-      "requires": {
-        "md5.js": "1.3.4",
-        "safe-buffer": "5.1.1"
-      }
+      "dev": true
     },
     "execa": {
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/execa/-/execa-0.7.0.tgz",
       "integrity": "sha1-lEvs00zEHuMqY6n68nrVpl/Fl3c=",
-      "dev": true,
-      "requires": {
-        "cross-spawn": "5.1.0",
-        "get-stream": "3.0.0",
-        "is-stream": "1.1.0",
-        "npm-run-path": "2.0.2",
-        "p-finally": "1.0.0",
-        "signal-exit": "3.0.2",
-        "strip-eof": "1.0.0"
-      }
+      "dev": true
     },
     "exists-stat": {
       "version": "1.0.0",
@@ -2499,57 +1589,37 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-0.1.5.tgz",
       "integrity": "sha1-3wcoTjQqgHzXM6xa9yQR5YHRF3s=",
-      "dev": true,
-      "requires": {
-        "is-posix-bracket": "0.1.1"
-      }
+      "dev": true
     },
     "expand-range": {
       "version": "1.8.2",
       "resolved": "https://registry.npmjs.org/expand-range/-/expand-range-1.8.2.tgz",
       "integrity": "sha1-opnv/TNf4nIeuujiV+x5ZE/IUzc=",
-      "dev": true,
-      "requires": {
-        "fill-range": "2.2.3"
-      }
+      "dev": true
     },
     "expand-tilde": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/expand-tilde/-/expand-tilde-2.0.2.tgz",
       "integrity": "sha1-l+gBqgUt8CRU3kawK/YhZCzchQI=",
-      "dev": true,
-      "requires": {
-        "homedir-polyfill": "1.0.1"
-      }
+      "dev": true
     },
     "extend-shallow": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-2.0.1.tgz",
       "integrity": "sha1-Ua99YUrZqfYQ6huvu5idaxxWiQ8=",
-      "dev": true,
-      "requires": {
-        "is-extendable": "0.1.1"
-      }
+      "dev": true
     },
     "external-editor": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/external-editor/-/external-editor-2.1.0.tgz",
       "integrity": "sha512-E44iT5QVOUJBKij4IIV3uvxuNlbKS38Tw1HiupxEIHPv9qtC2PrDYohbXV5U+1jnfIXttny8gUhj+oZvflFlzA==",
-      "dev": true,
-      "requires": {
-        "chardet": "0.4.2",
-        "iconv-lite": "0.4.19",
-        "tmp": "0.0.33"
-      }
+      "dev": true
     },
     "extglob": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/extglob/-/extglob-0.3.2.tgz",
       "integrity": "sha1-Lhj/PS9JqydlzskCPwEdqo2DSaE=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
+      "dev": true
     },
     "fast-deep-equal": {
       "version": "1.0.0",
@@ -2573,29 +1643,19 @@
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/faye-websocket/-/faye-websocket-0.11.1.tgz",
       "integrity": "sha1-8O/hjE9W5PQK/H4Gxxn9XuYYjzg=",
-      "dev": true,
-      "requires": {
-        "websocket-driver": "0.7.0"
-      }
+      "dev": true
     },
     "figures": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/figures/-/figures-2.0.0.tgz",
       "integrity": "sha1-OrGi0qYsi/tDGgyUy3l6L84nyWI=",
-      "dev": true,
-      "requires": {
-        "escape-string-regexp": "1.0.5"
-      }
+      "dev": true
     },
     "file-entry-cache": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/file-entry-cache/-/file-entry-cache-2.0.0.tgz",
       "integrity": "sha1-w5KZDD5oR4PYOLjISkXYoEhFg2E=",
-      "dev": true,
-      "requires": {
-        "flat-cache": "1.3.0",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "filename-regex": {
       "version": "2.0.1",
@@ -2607,35 +1667,19 @@
       "version": "2.2.3",
       "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-2.2.3.tgz",
       "integrity": "sha1-ULd9/X5Gm8dJJHCWNpn+eoSFpyM=",
-      "dev": true,
-      "requires": {
-        "is-number": "2.1.0",
-        "isobject": "2.1.0",
-        "randomatic": "1.1.7",
-        "repeat-element": "1.1.2",
-        "repeat-string": "1.6.1"
-      }
+      "dev": true
     },
     "find-up": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/find-up/-/find-up-2.1.0.tgz",
       "integrity": "sha1-RdG35QbHF93UgndaK3eSCjwMV6c=",
-      "dev": true,
-      "requires": {
-        "locate-path": "2.0.0"
-      }
+      "dev": true
     },
     "findup-sync": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/findup-sync/-/findup-sync-2.0.0.tgz",
       "integrity": "sha1-kyaxSIwi0aYIhlCoaQGy2akKLLw=",
       "dev": true,
-      "requires": {
-        "detect-file": "1.0.0",
-        "is-glob": "3.1.0",
-        "micromatch": "3.1.5",
-        "resolve-dir": "1.0.1"
-      },
       "dependencies": {
         "arr-diff": {
           "version": "4.0.0",
@@ -2653,44 +1697,19 @@
           "version": "2.3.0",
           "resolved": "https://registry.npmjs.org/braces/-/braces-2.3.0.tgz",
           "integrity": "sha512-P4O8UQRdGiMLWSizsApmXVQDBS6KCt7dSexgLKBmH5Hr1CZq7vsnscFh8oR1sP1ab1Zj0uCHCEzZeV6SfUf3rA==",
-          "dev": true,
-          "requires": {
-            "arr-flatten": "1.1.0",
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "extend-shallow": "2.0.1",
-            "fill-range": "4.0.0",
-            "isobject": "3.0.1",
-            "repeat-element": "1.1.2",
-            "snapdragon": "0.8.1",
-            "snapdragon-node": "2.1.1",
-            "split-string": "3.1.0",
-            "to-regex": "3.0.1"
-          }
+          "dev": true
         },
         "expand-brackets": {
           "version": "2.1.4",
           "resolved": "https://registry.npmjs.org/expand-brackets/-/expand-brackets-2.1.4.tgz",
           "integrity": "sha1-t3c14xXOMPa27/D4OwQVGiJEliI=",
           "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "define-property": "0.2.5",
-            "extend-shallow": "2.0.1",
-            "posix-character-classes": "0.1.1",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.1"
-          },
           "dependencies": {
             "define-property": {
               "version": "0.2.5",
               "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
               "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-              "dev": true,
-              "requires": {
-                "is-descriptor": "0.1.6"
-              }
+              "dev": true
             }
           }
         },
@@ -2698,47 +1717,25 @@
           "version": "2.0.4",
           "resolved": "https://registry.npmjs.org/extglob/-/extglob-2.0.4.tgz",
           "integrity": "sha512-Nmb6QXkELsuBr24CJSkilo6UHHgbekK5UiZgfE6UHD3Eb27YC6oD+bhcT+tJ6cl8dmsgdQxnWlcry8ksBIBLpw==",
-          "dev": true,
-          "requires": {
-            "array-unique": "0.3.2",
-            "define-property": "1.0.0",
-            "expand-brackets": "2.1.4",
-            "extend-shallow": "2.0.1",
-            "fragment-cache": "0.2.1",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.1"
-          }
+          "dev": true
         },
         "fill-range": {
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/fill-range/-/fill-range-4.0.0.tgz",
           "integrity": "sha1-1USBHUKPmOsGpj3EAtJAPDKMOPc=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "2.0.1",
-            "is-number": "3.0.0",
-            "repeat-string": "1.6.1",
-            "to-regex-range": "2.1.1"
-          }
+          "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "dev": true
             }
           }
         },
@@ -2747,18 +1744,12 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "dev": true
             }
           }
         },
@@ -2767,11 +1758,6 @@
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          },
           "dependencies": {
             "kind-of": {
               "version": "5.1.0",
@@ -2791,28 +1777,19 @@
           "version": "3.1.0",
           "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-3.1.0.tgz",
           "integrity": "sha1-e6WuJCF4BKxwcHuWkiVnSGzD6Eo=",
-          "dev": true,
-          "requires": {
-            "is-extglob": "2.1.1"
-          }
+          "dev": true
         },
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "dev": true
             }
           }
         },
@@ -2832,22 +1809,7 @@
           "version": "3.1.5",
           "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-3.1.5.tgz",
           "integrity": "sha512-ykttrLPQrz1PUJcXjwsTUjGoPJ64StIGNE2lGVD1c9CuguJ+L7/navsE8IcDNndOoCMvYV0qc/exfVbMHkUhvA==",
-          "dev": true,
-          "requires": {
-            "arr-diff": "4.0.0",
-            "array-unique": "0.3.2",
-            "braces": "2.3.0",
-            "define-property": "1.0.0",
-            "extend-shallow": "2.0.1",
-            "extglob": "2.0.4",
-            "fragment-cache": "0.2.1",
-            "kind-of": "6.0.2",
-            "nanomatch": "1.2.7",
-            "object.pick": "1.3.0",
-            "regex-not": "1.0.0",
-            "snapdragon": "0.8.1",
-            "to-regex": "3.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -2855,29 +1817,13 @@
       "version": "5.0.2",
       "resolved": "https://registry.npmjs.org/firebase/-/firebase-5.0.2.tgz",
       "integrity": "sha512-Tj1YeAozrFWb7qrHScWzjiYXXGmhHtGf3bdJIx96iE82MAusoNfgpMJE/nj0mQf9NwQFPxK4P3lOfQ8tUdE6MQ==",
-      "dev": true,
-      "requires": {
-        "@firebase/app": "0.3.1",
-        "@firebase/auth": "0.5.2",
-        "@firebase/database": "0.3.1",
-        "@firebase/firestore": "0.5.2",
-        "@firebase/functions": "0.2.2",
-        "@firebase/messaging": "0.3.2",
-        "@firebase/polyfill": "0.3.1",
-        "@firebase/storage": "0.2.2"
-      }
+      "dev": true
     },
     "flat-cache": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/flat-cache/-/flat-cache-1.3.0.tgz",
       "integrity": "sha1-0wMLMrOBVPTjt+nHCfSQ9++XxIE=",
-      "dev": true,
-      "requires": {
-        "circular-json": "0.3.3",
-        "del": "2.2.2",
-        "graceful-fs": "4.1.11",
-        "write": "0.2.1"
-      }
+      "dev": true
     },
     "for-in": {
       "version": "1.0.2",
@@ -2889,10 +1835,7 @@
       "version": "0.1.5",
       "resolved": "https://registry.npmjs.org/for-own/-/for-own-0.1.5.tgz",
       "integrity": "sha1-UmXGgaTylNq78XyVCbZ2OqhFEM4=",
-      "dev": true,
-      "requires": {
-        "for-in": "1.0.2"
-      }
+      "dev": true
     },
     "foreach": {
       "version": "2.0.5",
@@ -2904,10 +1847,7 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/fragment-cache/-/fragment-cache-0.2.1.tgz",
       "integrity": "sha1-QpD60n8T6Jvn8zeZxrxaCr//DRk=",
-      "dev": true,
-      "requires": {
-        "map-cache": "0.2.2"
-      }
+      "dev": true
     },
     "from": {
       "version": "0.1.7",
@@ -2933,10 +1873,6 @@
       "integrity": "sha512-WIr7iDkdmdbxu/Gh6eKEZJL6KPE74/5MEsf2whTOFNxbIoIixogroLdKYqB6FDav4Wavh/lZdzzd3b2KxIXC5Q==",
       "dev": true,
       "optional": true,
-      "requires": {
-        "nan": "2.8.0",
-        "node-pre-gyp": "0.6.39"
-      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.0",
@@ -2948,11 +1884,7 @@
           "version": "4.11.8",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "co": "4.6.0",
-            "json-stable-stringify": "1.0.1"
-          }
+          "optional": true
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -2969,11 +1901,7 @@
           "version": "1.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.2.9"
-          }
+          "optional": true
         },
         "asn1": {
           "version": "0.2.3",
@@ -3014,35 +1942,22 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
+          "optional": true
         },
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
+          "dev": true
         },
         "boom": {
           "version": "2.10.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.7",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "0.4.2",
-            "concat-map": "0.0.1"
-          }
+          "dev": true
         },
         "buffer-shims": {
           "version": "1.0.0",
@@ -3069,10 +1984,7 @@
         "combined-stream": {
           "version": "1.0.5",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -3092,19 +2004,13 @@
         "cryptiles": {
           "version": "2.0.5",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1"
-          }
+          "dev": true
         },
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
           "dev": true,
           "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -3118,10 +2024,7 @@
           "version": "2.6.8",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "optional": true
         },
         "deep-extend": {
           "version": "0.4.2",
@@ -3150,10 +2053,7 @@
           "version": "0.1.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
+          "optional": true
         },
         "extend": {
           "version": "3.0.1",
@@ -3176,12 +2076,7 @@
           "version": "2.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.5",
-            "mime-types": "2.1.15"
-          }
+          "optional": true
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -3191,49 +2086,25 @@
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.1"
-          }
+          "dev": true
         },
         "fstream-ignore": {
           "version": "1.0.5",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
+          "optional": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "aproba": "1.1.1",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
+          "optional": true
         },
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
           "dev": true,
           "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -3246,15 +2117,7 @@
         "glob": {
           "version": "7.1.2",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -3271,11 +2134,7 @@
           "version": "4.2.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "ajv": "4.11.8",
-            "har-schema": "1.0.5"
-          }
+          "optional": true
         },
         "has-unicode": {
           "version": "2.0.1",
@@ -3286,13 +2145,7 @@
         "hawk": {
           "version": "3.1.3",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "boom": "2.10.1",
-            "cryptiles": "2.0.5",
-            "hoek": "2.16.3",
-            "sntp": "1.0.9"
-          }
+          "dev": true
         },
         "hoek": {
           "version": "2.16.3",
@@ -3303,21 +2156,12 @@
           "version": "1.1.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "assert-plus": "0.2.0",
-            "jsprim": "1.4.0",
-            "sshpk": "1.13.0"
-          }
+          "optional": true
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
+          "dev": true
         },
         "inherits": {
           "version": "2.0.3",
@@ -3333,10 +2177,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "dev": true
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -3359,10 +2200,7 @@
           "version": "1.0.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
+          "optional": true
         },
         "jsbn": {
           "version": "0.1.1",
@@ -3380,10 +2218,7 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "jsonify": "0.0.0"
-          }
+          "optional": true
         },
         "json-stringify-safe": {
           "version": "5.0.1",
@@ -3402,12 +2237,6 @@
           "bundled": true,
           "dev": true,
           "optional": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.0.2",
-            "json-schema": "0.2.3",
-            "verror": "1.3.6"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -3425,18 +2254,12 @@
         "mime-types": {
           "version": "2.1.15",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.27.0"
-          }
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.7"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "0.0.8",
@@ -3446,10 +2269,7 @@
         "mkdirp": {
           "version": "0.5.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          }
+          "dev": true
         },
         "ms": {
           "version": "2.0.0",
@@ -3461,42 +2281,19 @@
           "version": "0.6.39",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "detect-libc": "1.0.2",
-            "hawk": "3.1.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.0",
-            "rc": "1.2.1",
-            "request": "2.81.0",
-            "rimraf": "2.6.1",
-            "semver": "5.3.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.0"
-          }
+          "optional": true
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "abbrev": "1.1.0",
-            "osenv": "0.1.4"
-          }
+          "optional": true
         },
         "npmlog": {
           "version": "4.1.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
+          "optional": true
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -3518,10 +2315,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
+          "dev": true
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -3539,11 +2333,7 @@
           "version": "0.1.4",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
+          "optional": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -3578,12 +2368,6 @@
           "bundled": true,
           "dev": true,
           "optional": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.4",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          },
           "dependencies": {
             "minimist": {
               "version": "1.2.0",
@@ -3596,54 +2380,18 @@
         "readable-stream": {
           "version": "2.2.9",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "buffer-shims": "1.0.0",
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "1.0.7",
-            "string_decoder": "1.0.1",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "request": {
           "version": "2.81.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "aws-sign2": "0.6.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.5",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.1.4",
-            "har-validator": "4.2.1",
-            "hawk": "3.1.3",
-            "http-signature": "1.1.1",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.15",
-            "oauth-sign": "0.8.2",
-            "performance-now": "0.2.0",
-            "qs": "6.4.0",
-            "safe-buffer": "5.0.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.2",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.0.1"
-          }
+          "optional": true
         },
         "rimraf": {
           "version": "2.6.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
+          "dev": true
         },
         "safe-buffer": {
           "version": "5.0.1",
@@ -3671,27 +2419,13 @@
         "sntp": {
           "version": "1.0.9",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "2.16.3"
-          }
+          "dev": true
         },
         "sshpk": {
           "version": "1.13.0",
           "bundled": true,
           "dev": true,
           "optional": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jodid25519": "1.0.2",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          },
           "dependencies": {
             "assert-plus": {
               "version": "1.0.0",
@@ -3701,23 +2435,15 @@
             }
           }
         },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
-        },
         "string_decoder": {
           "version": "1.0.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
         },
         "stringstream": {
           "version": "0.0.5",
@@ -3728,10 +2454,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+          "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -3742,46 +2465,25 @@
         "tar": {
           "version": "2.2.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
+          "dev": true
         },
         "tar-pack": {
           "version": "3.4.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "debug": "2.6.8",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.2.9",
-            "rimraf": "2.6.1",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
+          "optional": true
         },
         "tough-cookie": {
           "version": "2.3.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
+          "optional": true
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "safe-buffer": "5.0.1"
-          }
+          "optional": true
         },
         "tweetnacl": {
           "version": "0.14.5",
@@ -3810,19 +2512,13 @@
           "version": "1.3.6",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "extsprintf": "1.0.2"
-          }
+          "optional": true
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
+          "optional": true
         },
         "wrappy": {
           "version": "1.0.2",
@@ -3871,67 +2567,37 @@
       "version": "7.1.2",
       "resolved": "https://registry.npmjs.org/glob/-/glob-7.1.2.tgz",
       "integrity": "sha512-MJTUg1kjuLeQCJ+ccE4Vpa6kKVXkPYJ2mOCQyUuKLcLQsdrMCpBPUi8qVE6+YuaJkozeA9NusTAw3hLr8Xe5EQ==",
-      "dev": true,
-      "requires": {
-        "fs.realpath": "1.0.0",
-        "inflight": "1.0.6",
-        "inherits": "2.0.3",
-        "minimatch": "3.0.4",
-        "once": "1.4.0",
-        "path-is-absolute": "1.0.1"
-      }
+      "dev": true
     },
     "glob-base": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/glob-base/-/glob-base-0.3.0.tgz",
       "integrity": "sha1-27Fk9iIbHAscz4Kuoyi0l98Oo8Q=",
-      "dev": true,
-      "requires": {
-        "glob-parent": "2.0.0",
-        "is-glob": "2.0.1"
-      }
+      "dev": true
     },
     "glob-parent": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/glob-parent/-/glob-parent-2.0.0.tgz",
       "integrity": "sha1-gTg9ctsFT8zPUzbaqQLxgvbtuyg=",
-      "dev": true,
-      "requires": {
-        "is-glob": "2.0.1"
-      }
+      "dev": true
     },
     "global-dirs": {
       "version": "0.1.1",
       "resolved": "https://registry.npmjs.org/global-dirs/-/global-dirs-0.1.1.tgz",
       "integrity": "sha1-sxnA3UYH81PzvpzKTHL8FIxJ9EU=",
-      "dev": true,
-      "requires": {
-        "ini": "1.3.5"
-      }
+      "dev": true
     },
     "global-modules": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/global-modules/-/global-modules-1.0.0.tgz",
       "integrity": "sha512-sKzpEkf11GpOFuw0Zzjzmt4B4UZwjOcG757PPvrfhxcLFbq0wpsgpOqxpxtxFiCG4DtG93M6XRVbF2oGdev7bg==",
-      "dev": true,
-      "requires": {
-        "global-prefix": "1.0.2",
-        "is-windows": "1.0.2",
-        "resolve-dir": "1.0.1"
-      }
+      "dev": true
     },
     "global-prefix": {
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/global-prefix/-/global-prefix-1.0.2.tgz",
       "integrity": "sha1-2/dDxsFJklk8ZVVoy2btMsASLr4=",
-      "dev": true,
-      "requires": {
-        "expand-tilde": "2.0.2",
-        "homedir-polyfill": "1.0.1",
-        "ini": "1.3.5",
-        "is-windows": "1.0.2",
-        "which": "1.3.0"
-      }
+      "dev": true
     },
     "globals": {
       "version": "11.3.0",
@@ -3943,34 +2609,13 @@
       "version": "5.0.0",
       "resolved": "https://registry.npmjs.org/globby/-/globby-5.0.0.tgz",
       "integrity": "sha1-69hGZ8oNuzMLmbz8aOrCvFQ3Dg0=",
-      "dev": true,
-      "requires": {
-        "array-union": "1.0.2",
-        "arrify": "1.0.1",
-        "glob": "7.1.2",
-        "object-assign": "4.1.1",
-        "pify": "2.3.0",
-        "pinkie-promise": "2.0.1"
-      }
+      "dev": true
     },
     "got": {
       "version": "6.7.1",
       "resolved": "https://registry.npmjs.org/got/-/got-6.7.1.tgz",
       "integrity": "sha1-JAzQV4WpoY5WHcG0S0HHY+8ejbA=",
-      "dev": true,
-      "requires": {
-        "create-error-class": "3.0.2",
-        "duplexer3": "0.1.4",
-        "get-stream": "3.0.0",
-        "is-redirect": "1.0.0",
-        "is-retry-allowed": "1.1.0",
-        "is-stream": "1.1.0",
-        "lowercase-keys": "1.0.1",
-        "safe-buffer": "5.1.1",
-        "timed-out": "4.0.1",
-        "unzip-response": "2.0.1",
-        "url-parse-lax": "1.0.0"
-      }
+      "dev": true
     },
     "graceful-fs": {
       "version": "4.1.11",
@@ -3983,12 +2628,6 @@
       "resolved": "https://registry.npmjs.org/grpc/-/grpc-1.10.1.tgz",
       "integrity": "sha512-xmhA11h2XhqpSVzDAmoQAYdNQ+swILXpKOiRpAEQ2kX55ioxVADc6v7SkS4zQBxm4klhQHgGqpGKvoL6LGx4VQ==",
       "dev": true,
-      "requires": {
-        "lodash": "4.17.5",
-        "nan": "2.10.0",
-        "node-pre-gyp": "0.7.0",
-        "protobufjs": "5.0.2"
-      },
       "dependencies": {
         "abbrev": {
           "version": "1.1.1",
@@ -3998,13 +2637,7 @@
         "ajv": {
           "version": "5.5.2",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "co": "4.6.0",
-            "fast-deep-equal": "1.1.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
+          "dev": true
         },
         "ansi-regex": {
           "version": "2.1.1",
@@ -4019,11 +2652,7 @@
         "are-we-there-yet": {
           "version": "1.1.4",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "delegates": "1.0.0",
-            "readable-stream": "2.3.5"
-          }
+          "dev": true
         },
         "asn1": {
           "version": "0.2.3",
@@ -4059,35 +2688,22 @@
           "version": "1.0.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "tweetnacl": "0.14.5"
-          }
+          "optional": true
         },
         "block-stream": {
           "version": "0.0.9",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3"
-          }
+          "dev": true
         },
         "boom": {
           "version": "4.3.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
+          "dev": true
         },
         "brace-expansion": {
           "version": "1.1.8",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "balanced-match": "1.0.0",
-            "concat-map": "0.0.1"
-          }
+          "dev": true
         },
         "caseless": {
           "version": "0.12.0",
@@ -4107,10 +2723,7 @@
         "combined-stream": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "delayed-stream": "1.0.0"
-          }
+          "dev": true
         },
         "concat-map": {
           "version": "0.0.1",
@@ -4131,35 +2744,23 @@
           "version": "3.1.2",
           "bundled": true,
           "dev": true,
-          "requires": {
-            "boom": "5.2.0"
-          },
           "dependencies": {
             "boom": {
               "version": "5.2.0",
               "bundled": true,
-              "dev": true,
-              "requires": {
-                "hoek": "4.2.1"
-              }
+              "dev": true
             }
           }
         },
         "dashdash": {
           "version": "1.14.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
+          "dev": true
         },
         "debug": {
           "version": "2.6.9",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "ms": "2.0.0"
-          }
+          "dev": true
         },
         "deep-extend": {
           "version": "0.4.2",
@@ -4185,10 +2786,7 @@
           "version": "0.1.1",
           "bundled": true,
           "dev": true,
-          "optional": true,
-          "requires": {
-            "jsbn": "0.1.1"
-          }
+          "optional": true
         },
         "extend": {
           "version": "3.0.1",
@@ -4218,12 +2816,7 @@
         "form-data": {
           "version": "2.3.2",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "asynckit": "0.4.0",
-            "combined-stream": "1.0.6",
-            "mime-types": "2.1.18"
-          }
+          "dev": true
         },
         "fs.realpath": {
           "version": "1.0.0",
@@ -4233,59 +2826,27 @@
         "fstream": {
           "version": "1.0.11",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "inherits": "2.0.3",
-            "mkdirp": "0.5.1",
-            "rimraf": "2.6.2"
-          }
+          "dev": true
         },
         "fstream-ignore": {
           "version": "1.0.5",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "fstream": "1.0.11",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4"
-          }
+          "dev": true
         },
         "gauge": {
           "version": "2.7.4",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "aproba": "1.2.0",
-            "console-control-strings": "1.1.0",
-            "has-unicode": "2.0.1",
-            "object-assign": "4.1.1",
-            "signal-exit": "3.0.2",
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wide-align": "1.1.2"
-          }
+          "dev": true
         },
         "getpass": {
           "version": "0.1.7",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0"
-          }
+          "dev": true
         },
         "glob": {
           "version": "7.1.2",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "fs.realpath": "1.0.0",
-            "inflight": "1.0.6",
-            "inherits": "2.0.3",
-            "minimatch": "3.0.4",
-            "once": "1.4.0",
-            "path-is-absolute": "1.0.1"
-          }
+          "dev": true
         },
         "graceful-fs": {
           "version": "4.1.11",
@@ -4300,11 +2861,7 @@
         "har-validator": {
           "version": "5.0.3",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "ajv": "5.5.2",
-            "har-schema": "2.0.0"
-          }
+          "dev": true
         },
         "has-unicode": {
           "version": "2.0.1",
@@ -4314,13 +2871,7 @@
         "hawk": {
           "version": "6.0.2",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "boom": "4.3.1",
-            "cryptiles": "3.1.2",
-            "hoek": "4.2.1",
-            "sntp": "2.1.0"
-          }
+          "dev": true
         },
         "hoek": {
           "version": "4.2.1",
@@ -4330,21 +2881,12 @@
         "http-signature": {
           "version": "1.2.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "jsprim": "1.4.1",
-            "sshpk": "1.14.1"
-          }
+          "dev": true
         },
         "inflight": {
           "version": "1.0.6",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "once": "1.4.0",
-            "wrappy": "1.0.2"
-          }
+          "dev": true
         },
         "inherits": {
           "version": "2.0.3",
@@ -4359,10 +2901,7 @@
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "dev": true
         },
         "is-typedarray": {
           "version": "1.0.0",
@@ -4403,13 +2942,7 @@
         "jsprim": {
           "version": "1.4.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "extsprintf": "1.3.0",
-            "json-schema": "0.2.3",
-            "verror": "1.10.0"
-          }
+          "dev": true
         },
         "mime-db": {
           "version": "1.33.0",
@@ -4419,18 +2952,12 @@
         "mime-types": {
           "version": "2.1.18",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "mime-db": "1.33.0"
-          }
+          "dev": true
         },
         "minimatch": {
           "version": "3.0.4",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "brace-expansion": "1.1.8"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
@@ -4441,9 +2968,6 @@
           "version": "0.5.1",
           "bundled": true,
           "dev": true,
-          "requires": {
-            "minimist": "0.0.8"
-          },
           "dependencies": {
             "minimist": {
               "version": "0.0.8",
@@ -4466,39 +2990,17 @@
         "node-pre-gyp": {
           "version": "0.7.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "detect-libc": "1.0.3",
-            "mkdirp": "0.5.1",
-            "nopt": "4.0.1",
-            "npmlog": "4.1.2",
-            "rc": "1.2.6",
-            "request": "2.83.0",
-            "rimraf": "2.6.2",
-            "semver": "5.5.0",
-            "tar": "2.2.1",
-            "tar-pack": "3.4.1"
-          }
+          "dev": true
         },
         "nopt": {
           "version": "4.0.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "abbrev": "1.1.1",
-            "osenv": "0.1.5"
-          }
+          "dev": true
         },
         "npmlog": {
           "version": "4.1.2",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "are-we-there-yet": "1.1.4",
-            "console-control-strings": "1.1.0",
-            "gauge": "2.7.4",
-            "set-blocking": "2.0.0"
-          }
+          "dev": true
         },
         "number-is-nan": {
           "version": "1.0.1",
@@ -4518,10 +3020,7 @@
         "once": {
           "version": "1.4.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "wrappy": "1.0.2"
-          }
+          "dev": true
         },
         "os-homedir": {
           "version": "1.0.2",
@@ -4536,11 +3035,7 @@
         "osenv": {
           "version": "0.1.5",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "os-homedir": "1.0.2",
-            "os-tmpdir": "1.0.2"
-          }
+          "dev": true
         },
         "path-is-absolute": {
           "version": "1.0.1",
@@ -4570,64 +3065,22 @@
         "rc": {
           "version": "1.2.6",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "deep-extend": "0.4.2",
-            "ini": "1.3.5",
-            "minimist": "1.2.0",
-            "strip-json-comments": "2.0.1"
-          }
+          "dev": true
         },
         "readable-stream": {
           "version": "2.3.5",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "core-util-is": "1.0.2",
-            "inherits": "2.0.3",
-            "isarray": "1.0.0",
-            "process-nextick-args": "2.0.0",
-            "safe-buffer": "5.1.1",
-            "string_decoder": "1.0.3",
-            "util-deprecate": "1.0.2"
-          }
+          "dev": true
         },
         "request": {
           "version": "2.83.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "aws-sign2": "0.7.0",
-            "aws4": "1.6.0",
-            "caseless": "0.12.0",
-            "combined-stream": "1.0.6",
-            "extend": "3.0.1",
-            "forever-agent": "0.6.1",
-            "form-data": "2.3.2",
-            "har-validator": "5.0.3",
-            "hawk": "6.0.2",
-            "http-signature": "1.2.0",
-            "is-typedarray": "1.0.0",
-            "isstream": "0.1.2",
-            "json-stringify-safe": "5.0.1",
-            "mime-types": "2.1.18",
-            "oauth-sign": "0.8.2",
-            "performance-now": "2.1.0",
-            "qs": "6.5.1",
-            "safe-buffer": "5.1.1",
-            "stringstream": "0.0.5",
-            "tough-cookie": "2.3.4",
-            "tunnel-agent": "0.6.0",
-            "uuid": "3.2.1"
-          }
+          "dev": true
         },
         "rimraf": {
           "version": "2.6.2",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "glob": "7.1.2"
-          }
+          "dev": true
         },
         "safe-buffer": {
           "version": "5.1.1",
@@ -4652,43 +3105,22 @@
         "sntp": {
           "version": "2.1.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "hoek": "4.2.1"
-          }
+          "dev": true
         },
         "sshpk": {
           "version": "1.14.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "asn1": "0.2.3",
-            "assert-plus": "1.0.0",
-            "bcrypt-pbkdf": "1.0.1",
-            "dashdash": "1.14.1",
-            "ecc-jsbn": "0.1.1",
-            "getpass": "0.1.7",
-            "jsbn": "0.1.1",
-            "tweetnacl": "0.14.5"
-          }
-        },
-        "string-width": {
-          "version": "1.0.2",
-          "bundled": true,
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
+          "dev": true
         },
         "string_decoder": {
           "version": "1.0.3",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "dev": true
+        },
+        "string-width": {
+          "version": "1.0.2",
+          "bundled": true,
+          "dev": true
         },
         "stringstream": {
           "version": "0.0.5",
@@ -4698,10 +3130,7 @@
         "strip-ansi": {
           "version": "3.0.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+          "dev": true
         },
         "strip-json-comments": {
           "version": "2.0.1",
@@ -4711,43 +3140,22 @@
         "tar": {
           "version": "2.2.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "block-stream": "0.0.9",
-            "fstream": "1.0.11",
-            "inherits": "2.0.3"
-          }
+          "dev": true
         },
         "tar-pack": {
           "version": "3.4.1",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "debug": "2.6.9",
-            "fstream": "1.0.11",
-            "fstream-ignore": "1.0.5",
-            "once": "1.4.0",
-            "readable-stream": "2.3.5",
-            "rimraf": "2.6.2",
-            "tar": "2.2.1",
-            "uid-number": "0.0.6"
-          }
+          "dev": true
         },
         "tough-cookie": {
           "version": "2.3.4",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "punycode": "1.4.1"
-          }
+          "dev": true
         },
         "tunnel-agent": {
           "version": "0.6.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "safe-buffer": "5.1.1"
-          }
+          "dev": true
         },
         "tweetnacl": {
           "version": "0.14.5",
@@ -4773,20 +3181,12 @@
         "verror": {
           "version": "1.10.0",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "assert-plus": "1.0.0",
-            "core-util-is": "1.0.2",
-            "extsprintf": "1.3.0"
-          }
+          "dev": true
         },
         "wide-align": {
           "version": "1.1.2",
           "bundled": true,
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2"
-          }
+          "dev": true
         },
         "wrappy": {
           "version": "1.0.2",
@@ -4799,19 +3199,12 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has/-/has-1.0.1.tgz",
       "integrity": "sha1-hGFzP1OLCDfJNh45qauelwTcLyg=",
-      "dev": true,
-      "requires": {
-        "function-bind": "1.1.1"
-      }
+      "dev": true
     },
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
-      "dev": true,
-      "requires": {
-        "ansi-regex": "2.1.1"
-      }
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
     },
     "has-flag": {
       "version": "3.0.0",
@@ -4824,11 +3217,6 @@
       "resolved": "https://registry.npmjs.org/has-value/-/has-value-1.0.0.tgz",
       "integrity": "sha1-GLKB2lhbHFxR3vJMkw7SmgvmsXc=",
       "dev": true,
-      "requires": {
-        "get-value": "2.0.6",
-        "has-values": "1.0.0",
-        "isobject": "3.0.1"
-      },
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
@@ -4843,28 +3231,18 @@
       "resolved": "https://registry.npmjs.org/has-values/-/has-values-1.0.0.tgz",
       "integrity": "sha1-lbC2P+whRmGab+V/51Yo1aOe/k8=",
       "dev": true,
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
-      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "dev": true
             }
           }
         },
@@ -4872,10 +3250,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
+          "dev": true
         }
       }
     },
@@ -4883,50 +3258,31 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-2.0.2.tgz",
       "integrity": "sha1-ZuodhW206KVHDK32/OI65SRO8uE=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3"
-      }
+      "dev": true
     },
     "hash.js": {
       "version": "1.1.3",
       "resolved": "https://registry.npmjs.org/hash.js/-/hash.js-1.1.3.tgz",
       "integrity": "sha512-/UETyP0W22QILqS+6HowevwhEFJ3MBJnwTf75Qob9Wz9t0DPuisL8kW8YZMK62dHAKE1c1p+gY1TtOLY+USEHA==",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "minimalistic-assert": "1.0.0"
-      }
+      "dev": true
     },
     "hmac-drbg": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/hmac-drbg/-/hmac-drbg-1.0.1.tgz",
       "integrity": "sha1-0nRXAQJabHdabFRXk+1QL8DGSaE=",
-      "dev": true,
-      "requires": {
-        "hash.js": "1.1.3",
-        "minimalistic-assert": "1.0.0",
-        "minimalistic-crypto-utils": "1.0.1"
-      }
+      "dev": true
     },
     "home-or-tmp": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/home-or-tmp/-/home-or-tmp-2.0.0.tgz",
       "integrity": "sha1-42w/LSyufXRqhX440Y1fMqeILbg=",
-      "dev": true,
-      "requires": {
-        "os-homedir": "1.0.2",
-        "os-tmpdir": "1.0.2"
-      }
+      "dev": true
     },
     "homedir-polyfill": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/homedir-polyfill/-/homedir-polyfill-1.0.1.tgz",
       "integrity": "sha1-TCu8inWJmP7r9e1oWA921GdotLw=",
-      "dev": true,
-      "requires": {
-        "parse-passwd": "1.0.0"
-      }
+      "dev": true
     },
     "hosted-git-info": {
       "version": "2.5.0",
@@ -4980,10 +3336,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/indent-string/-/indent-string-2.1.0.tgz",
       "integrity": "sha1-ji1INIdCEhtKghi3oTfppSBJ3IA=",
-      "dev": true,
-      "requires": {
-        "repeating": "2.0.1"
-      }
+      "dev": true
     },
     "indexof": {
       "version": "0.0.1",
@@ -4995,11 +3348,7 @@
       "version": "1.0.6",
       "resolved": "https://registry.npmjs.org/inflight/-/inflight-1.0.6.tgz",
       "integrity": "sha1-Sb1jMdfQLQwJvJEKEHW6gWW1bfk=",
-      "dev": true,
-      "requires": {
-        "once": "1.4.0",
-        "wrappy": "1.0.2"
-      }
+      "dev": true
     },
     "inherits": {
       "version": "2.0.3",
@@ -5017,23 +3366,7 @@
       "version": "3.3.0",
       "resolved": "https://registry.npmjs.org/inquirer/-/inquirer-3.3.0.tgz",
       "integrity": "sha512-h+xtnyk4EwKvFWHrUYsWErEVR+igKtLdchu+o0Z1RL7VU/jVMFbYir2bp6bAj8efFNxWqHX0dIss6fJQ+/+qeQ==",
-      "dev": true,
-      "requires": {
-        "ansi-escapes": "3.0.0",
-        "chalk": "2.3.1",
-        "cli-cursor": "2.1.0",
-        "cli-width": "2.2.0",
-        "external-editor": "2.1.0",
-        "figures": "2.0.0",
-        "lodash": "4.17.5",
-        "mute-stream": "0.0.7",
-        "run-async": "2.3.0",
-        "rx-lite": "4.0.8",
-        "rx-lite-aggregates": "4.0.8",
-        "string-width": "2.1.1",
-        "strip-ansi": "4.0.0",
-        "through": "2.3.8"
-      }
+      "dev": true
     },
     "interpret": {
       "version": "1.1.0",
@@ -5044,11 +3377,7 @@
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
-      "dev": true,
-      "requires": {
-        "loose-envify": "1.3.1"
-      }
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA=="
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -5061,9 +3390,6 @@
       "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-1.0.0.tgz",
       "integrity": "sha512-m5hnHTkcVsPfqx3AKlyttIPb7J+XykHvJP2B9bZDjlhLIoEq4XoK64Vg7boZlVWYK6LUY94dYPEE7Lh0ZkZKcQ==",
       "dev": true,
-      "requires": {
-        "kind-of": "6.0.2"
-      },
       "dependencies": {
         "kind-of": {
           "version": "6.0.2",
@@ -5083,10 +3409,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-binary-path/-/is-binary-path-1.0.1.tgz",
       "integrity": "sha1-dfFmQrSA8YenEcgUFh/TpKdlWJg=",
-      "dev": true,
-      "requires": {
-        "binary-extensions": "1.11.0"
-      }
+      "dev": true
     },
     "is-buffer": {
       "version": "1.1.6",
@@ -5098,10 +3421,7 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-builtin-module/-/is-builtin-module-1.0.0.tgz",
       "integrity": "sha1-VAVy0096wxGfj3bDDLwbHgN6/74=",
-      "dev": true,
-      "requires": {
-        "builtin-modules": "1.1.1"
-      }
+      "dev": true
     },
     "is-callable": {
       "version": "1.1.3",
@@ -5113,19 +3433,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/is-ci/-/is-ci-1.1.0.tgz",
       "integrity": "sha512-c7TnwxLePuqIlxHgr7xtxzycJPegNHFuIrBkwbf8hc58//+Op1CqFkyS+xnIMkwn9UsJIwc174BIjkyBmSpjKg==",
-      "dev": true,
-      "requires": {
-        "ci-info": "1.1.3"
-      }
+      "dev": true
     },
     "is-data-descriptor": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-1.0.0.tgz",
       "integrity": "sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==",
       "dev": true,
-      "requires": {
-        "kind-of": "6.0.2"
-      },
       "dependencies": {
         "kind-of": {
           "version": "6.0.2",
@@ -5146,11 +3460,6 @@
       "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-1.0.2.tgz",
       "integrity": "sha512-2eis5WqQGV7peooDyLmNEPUrps9+SXX5c9pL3xEB+4e9HnGuDa7mB7kHxHw4CbqS9k1T2hOH3miL8n8WtiYVtg==",
       "dev": true,
-      "requires": {
-        "is-accessor-descriptor": "1.0.0",
-        "is-data-descriptor": "1.0.0",
-        "kind-of": "6.0.2"
-      },
       "dependencies": {
         "kind-of": {
           "version": "6.0.2",
@@ -5170,10 +3479,7 @@
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/is-equal-shallow/-/is-equal-shallow-0.1.3.tgz",
       "integrity": "sha1-IjgJj8Ih3gvPpdnqxMRdY4qhxTQ=",
-      "dev": true,
-      "requires": {
-        "is-primitive": "2.0.0"
-      }
+      "dev": true
     },
     "is-extendable": {
       "version": "0.1.1",
@@ -5191,10 +3497,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/is-finite/-/is-finite-1.0.2.tgz",
       "integrity": "sha1-zGZ3aVYCvlUO8R6LSqYwU0K20Ko=",
-      "dev": true,
-      "requires": {
-        "number-is-nan": "1.0.1"
-      }
+      "dev": true
     },
     "is-fullwidth-code-point": {
       "version": "2.0.0",
@@ -5206,20 +3509,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/is-glob/-/is-glob-2.0.1.tgz",
       "integrity": "sha1-0Jb5JqPe1WAPP9/ZEZjLCIjC2GM=",
-      "dev": true,
-      "requires": {
-        "is-extglob": "1.0.0"
-      }
+      "dev": true
     },
     "is-installed-globally": {
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/is-installed-globally/-/is-installed-globally-0.1.0.tgz",
       "integrity": "sha1-Df2Y9akRFxbdU13aZJL2e/PSWoA=",
-      "dev": true,
-      "requires": {
-        "global-dirs": "0.1.1",
-        "is-path-inside": "1.0.1"
-      }
+      "dev": true
     },
     "is-npm": {
       "version": "1.0.0",
@@ -5231,10 +3527,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/is-number/-/is-number-2.1.0.tgz",
       "integrity": "sha1-Afy7s5NGOlSPL0ZszhbezknbkI8=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2"
-      }
+      "dev": true
     },
     "is-obj": {
       "version": "1.0.1",
@@ -5247,18 +3540,12 @@
       "resolved": "https://registry.npmjs.org/is-odd/-/is-odd-1.0.0.tgz",
       "integrity": "sha1-O4qTLrAos3dcObsJ6RdnrM22kIg=",
       "dev": true,
-      "requires": {
-        "is-number": "3.0.0"
-      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
+          "dev": true
         }
       }
     },
@@ -5272,28 +3559,19 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/is-path-in-cwd/-/is-path-in-cwd-1.0.0.tgz",
       "integrity": "sha1-ZHdYK4IU1gI0YJRWcAO+ip6sBNw=",
-      "dev": true,
-      "requires": {
-        "is-path-inside": "1.0.1"
-      }
+      "dev": true
     },
     "is-path-inside": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/is-path-inside/-/is-path-inside-1.0.1.tgz",
       "integrity": "sha1-jvW33lBDej/cprToZe96pVy0gDY=",
-      "dev": true,
-      "requires": {
-        "path-is-inside": "1.0.2"
-      }
+      "dev": true
     },
     "is-plain-object": {
       "version": "2.0.4",
       "resolved": "https://registry.npmjs.org/is-plain-object/-/is-plain-object-2.0.4.tgz",
       "integrity": "sha512-h5PpgXkWitc38BBMYawTYMWJHFZJVnBquFE57xFpjB8pJFiF6gZ+bU+WyI/yqXiFR5mdLsgYNaPe8uao6Uv9Og==",
       "dev": true,
-      "requires": {
-        "isobject": "3.0.1"
-      },
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
@@ -5331,10 +3609,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/is-regex/-/is-regex-1.0.4.tgz",
       "integrity": "sha1-VRdIm1RwkbCTDglWVM7SXul+lJE=",
-      "dev": true,
-      "requires": {
-        "has": "1.0.1"
-      }
+      "dev": true
     },
     "is-resolvable": {
       "version": "1.1.0",
@@ -5388,20 +3663,13 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
       "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-      "dev": true,
-      "requires": {
-        "isarray": "1.0.0"
-      }
+      "dev": true
     },
     "isomorphic-fetch": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/isomorphic-fetch/-/isomorphic-fetch-2.2.1.tgz",
       "integrity": "sha1-YRrhrPFPXoH3KVB0coGf6XM1WKk=",
-      "dev": true,
-      "requires": {
-        "node-fetch": "1.7.3",
-        "whatwg-fetch": "2.0.4"
-      }
+      "dev": true
     },
     "js-reporters": {
       "version": "1.2.1",
@@ -5412,18 +3680,13 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
-      "dev": true
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
     },
     "js-yaml": {
       "version": "3.10.0",
       "resolved": "https://registry.npmjs.org/js-yaml/-/js-yaml-3.10.0.tgz",
       "integrity": "sha512-O2v52ffjLa9VeM43J4XocZE//WT9N0IiwDa3KSHH7Tu8CtH+1qM8SIZvnsTh6v+4yFy5KUY3BHUVwjpfAWsjIA==",
-      "dev": true,
-      "requires": {
-        "argparse": "1.0.10",
-        "esprima": "4.0.0"
-      }
+      "dev": true
     },
     "jsesc": {
       "version": "1.3.0",
@@ -5477,59 +3740,37 @@
       "version": "3.2.2",
       "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
       "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-      "dev": true,
-      "requires": {
-        "is-buffer": "1.1.6"
-      }
+      "dev": true
     },
     "latest-version": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/latest-version/-/latest-version-3.1.0.tgz",
       "integrity": "sha1-ogU4P+oyKzO1rjsYq+4NwvNW7hU=",
-      "dev": true,
-      "requires": {
-        "package-json": "4.0.1"
-      }
+      "dev": true
     },
     "lazy-cache": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/lazy-cache/-/lazy-cache-2.0.2.tgz",
       "integrity": "sha1-uRkKT5EzVGlIQIWfio9whNiCImQ=",
-      "dev": true,
-      "requires": {
-        "set-getter": "0.1.0"
-      }
+      "dev": true
     },
     "lcid": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/lcid/-/lcid-1.0.0.tgz",
       "integrity": "sha1-MIrMr6C8SDo4Z7S28rlQYlHRuDU=",
-      "dev": true,
-      "requires": {
-        "invert-kv": "1.0.0"
-      }
+      "dev": true
     },
     "levn": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/levn/-/levn-0.3.0.tgz",
       "integrity": "sha1-OwmSTt+fCDwEkP3UwLxEIeBHZO4=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2"
-      }
+      "dev": true
     },
     "load-json-file": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-4.0.0.tgz",
       "integrity": "sha1-L19Fq5HjMhYjT9U62rZo607AmTs=",
       "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "parse-json": "4.0.0",
-        "pify": "3.0.0",
-        "strip-bom": "3.0.0"
-      },
       "dependencies": {
         "pify": {
           "version": "3.0.0",
@@ -5549,28 +3790,18 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/loader-utils/-/loader-utils-1.1.0.tgz",
       "integrity": "sha1-yYrvSIvM7aL/teLeZG1qdUQp9c0=",
-      "dev": true,
-      "requires": {
-        "big.js": "3.2.0",
-        "emojis-list": "2.1.0",
-        "json5": "0.5.1"
-      }
+      "dev": true
     },
     "locate-path": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/locate-path/-/locate-path-2.0.0.tgz",
       "integrity": "sha1-K1aLJl7slExtnA3pw9u7ygNUzY4=",
-      "dev": true,
-      "requires": {
-        "p-locate": "2.0.0",
-        "path-exists": "3.0.0"
-      }
+      "dev": true
     },
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
-      "dev": true
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
     },
     "lodash.cond": {
       "version": "4.5.2",
@@ -5605,21 +3836,13 @@
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
-      "dev": true,
-      "requires": {
-        "js-tokens": "3.0.2"
-      }
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
     },
     "loud-rejection": {
       "version": "1.6.0",
       "resolved": "https://registry.npmjs.org/loud-rejection/-/loud-rejection-1.6.0.tgz",
       "integrity": "sha1-W0b4AUft7leIcPCG0Eghz5mOVR8=",
-      "dev": true,
-      "requires": {
-        "currently-unhandled": "0.4.1",
-        "signal-exit": "3.0.2"
-      }
+      "dev": true
     },
     "lowercase-keys": {
       "version": "1.0.1",
@@ -5631,28 +3854,7 @@
       "version": "4.1.1",
       "resolved": "https://registry.npmjs.org/lru-cache/-/lru-cache-4.1.1.tgz",
       "integrity": "sha512-q4spe4KTfsAS1SUHLO0wz8Qiyf1+vMIAgpRYioFYDMNqKfHQbg+AVDH3i4fvpl71/P1L0dBl+fQi+P37UYf0ew==",
-      "dev": true,
-      "requires": {
-        "pseudomap": "1.0.2",
-        "yallist": "2.1.2"
-      }
-    },
-    "make-dir": {
-      "version": "1.3.0",
-      "resolved": "https://registry.npmjs.org/make-dir/-/make-dir-1.3.0.tgz",
-      "integrity": "sha512-2w31R7SJtieJJnQtGc7RVL2StM2vGYVfqUOvUDxH6bC6aJTxPxTF0GnIgCyu7tjockiUWAYQRbxa7vKn34s5sQ==",
-      "dev": true,
-      "requires": {
-        "pify": "3.0.0"
-      },
-      "dependencies": {
-        "pify": {
-          "version": "3.0.0",
-          "resolved": "https://registry.npmjs.org/pify/-/pify-3.0.0.tgz",
-          "integrity": "sha1-5aSs0sEB/fPZpNB/DbxNtJ3SgXY=",
-          "dev": true
-        }
-      }
+      "dev": true
     },
     "map-cache": {
       "version": "0.2.2",
@@ -5676,39 +3878,25 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/map-visit/-/map-visit-1.0.0.tgz",
       "integrity": "sha1-7Nyo8TFE5mDxtb1B8S80edmN+48=",
-      "dev": true,
-      "requires": {
-        "object-visit": "1.0.1"
-      }
+      "dev": true
     },
     "matcher-collection": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/matcher-collection/-/matcher-collection-1.0.5.tgz",
       "integrity": "sha512-nUCmzKipcJEwYsBVAFh5P+d7JBuhJaW1xs85Hara9xuMLqtCVUrW6DSC0JVIkluxEH2W45nPBM/wjHtBXa/tYA==",
-      "dev": true,
-      "requires": {
-        "minimatch": "3.0.4"
-      }
+      "dev": true
     },
     "md5.js": {
       "version": "1.3.4",
       "resolved": "https://registry.npmjs.org/md5.js/-/md5.js-1.3.4.tgz",
       "integrity": "sha1-6b296UogpawYsENA/Fdk1bCdkB0=",
       "dev": true,
-      "requires": {
-        "hash-base": "3.0.4",
-        "inherits": "2.0.3"
-      },
       "dependencies": {
         "hash-base": {
           "version": "3.0.4",
           "resolved": "https://registry.npmjs.org/hash-base/-/hash-base-3.0.4.tgz",
           "integrity": "sha1-X8hoaEfs1zSZQDMZprCj8/auSRg=",
-          "dev": true,
-          "requires": {
-            "inherits": "2.0.3",
-            "safe-buffer": "5.1.1"
-          }
+          "dev": true
         }
       }
     },
@@ -5716,20 +3904,13 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/mem/-/mem-1.1.0.tgz",
       "integrity": "sha1-Xt1StIXKHZAP5kiVUFOZoN+kX3Y=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "1.2.0"
-      }
+      "dev": true
     },
     "memory-fs": {
       "version": "0.4.1",
       "resolved": "https://registry.npmjs.org/memory-fs/-/memory-fs-0.4.1.tgz",
       "integrity": "sha1-OpoguEYlI+RHz7x+i7gO1me/xVI=",
-      "dev": true,
-      "requires": {
-        "errno": "0.1.7",
-        "readable-stream": "2.3.4"
-      }
+      "dev": true
     },
     "memorystream": {
       "version": "0.3.1",
@@ -5742,41 +3923,18 @@
       "resolved": "https://registry.npmjs.org/meow/-/meow-3.7.0.tgz",
       "integrity": "sha1-cstmi0JSKCkKu/qFaJJYcwioAfs=",
       "dev": true,
-      "requires": {
-        "camelcase-keys": "2.1.0",
-        "decamelize": "1.2.0",
-        "loud-rejection": "1.6.0",
-        "map-obj": "1.0.1",
-        "minimist": "1.2.0",
-        "normalize-package-data": "2.4.0",
-        "object-assign": "4.1.1",
-        "read-pkg-up": "1.0.1",
-        "redent": "1.0.0",
-        "trim-newlines": "1.0.0"
-      },
       "dependencies": {
         "find-up": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         },
         "load-json-file": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-1.1.0.tgz",
           "integrity": "sha1-lWkFcI1YtLq0wiYbBPWfMcmTdMA=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1",
-            "strip-bom": "2.0.0"
-          }
+          "dev": true
         },
         "minimist": {
           "version": "1.2.0",
@@ -5788,60 +3946,37 @@
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
+          "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         },
         "path-type": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-1.1.0.tgz",
           "integrity": "sha1-WcRPfuSR2nBNpBXaWkBwuk+P5EE=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "pify": "2.3.0",
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         },
         "read-pkg": {
           "version": "1.1.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-1.1.0.tgz",
           "integrity": "sha1-9f+qXs0pyzHAR0vKfXVra7KePyg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "1.1.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "1.1.0"
-          }
+          "dev": true
         },
         "read-pkg-up": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-1.0.1.tgz",
           "integrity": "sha1-nWPBMnbAZZGNV/ACpX9AobZD+wI=",
-          "dev": true,
-          "requires": {
-            "find-up": "1.1.2",
-            "read-pkg": "1.1.0"
-          }
+          "dev": true
         },
         "strip-bom": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/strip-bom/-/strip-bom-2.0.0.tgz",
           "integrity": "sha1-YhmoVhZSBJHzV4i9vxRHqZx+aw4=",
-          "dev": true,
-          "requires": {
-            "is-utf8": "0.2.1"
-          }
+          "dev": true
         }
       }
     },
@@ -5849,32 +3984,13 @@
       "version": "2.3.11",
       "resolved": "https://registry.npmjs.org/micromatch/-/micromatch-2.3.11.tgz",
       "integrity": "sha1-hmd8l9FyCzY0MdBNDRUpO9OMFWU=",
-      "dev": true,
-      "requires": {
-        "arr-diff": "2.0.0",
-        "array-unique": "0.2.1",
-        "braces": "1.8.5",
-        "expand-brackets": "0.1.5",
-        "extglob": "0.3.2",
-        "filename-regex": "2.0.1",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1",
-        "kind-of": "3.2.2",
-        "normalize-path": "2.1.1",
-        "object.omit": "2.0.1",
-        "parse-glob": "3.0.4",
-        "regex-cache": "0.4.4"
-      }
+      "dev": true
     },
     "miller-rabin": {
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/miller-rabin/-/miller-rabin-4.0.1.tgz",
       "integrity": "sha512-115fLhvZVqWwHPbClyntxEVfVDfl9DLLTuJvq3g2O/Oxi8AiNouAHvDSzHS0viUJc+V5vm3eq91Xwqn9dp4jRA==",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "brorand": "1.1.0"
-      }
+      "dev": true
     },
     "mimic-fn": {
       "version": "1.2.0",
@@ -5898,10 +4014,7 @@
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/minimatch/-/minimatch-3.0.4.tgz",
       "integrity": "sha512-yJHVQEhyqPLUTgt9B83PXu6W3rx4MvvHvSUvToogpwoGDOUQ+yDrR0HRot+yOCdCO7u4hX3pWft6kWBBcqh0UA==",
-      "dev": true,
-      "requires": {
-        "brace-expansion": "1.1.11"
-      }
+      "dev": true
     },
     "minimist": {
       "version": "0.0.8",
@@ -5914,19 +4027,12 @@
       "resolved": "https://registry.npmjs.org/mixin-deep/-/mixin-deep-1.3.1.tgz",
       "integrity": "sha512-8ZItLHeEgaqEvd5lYBXfm4EZSFCX29Jb9K+lAHhDKzReKBQKj3R+7NOF6tjqYi9t4oI8VUfaWITJQm86wnXGNQ==",
       "dev": true,
-      "requires": {
-        "for-in": "1.0.2",
-        "is-extendable": "1.0.1"
-      },
       "dependencies": {
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "dev": true,
-          "requires": {
-            "is-plain-object": "2.0.4"
-          }
+          "dev": true
         }
       }
     },
@@ -5934,16 +4040,12 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/mkdirp/-/mkdirp-0.5.1.tgz",
       "integrity": "sha1-MAV0OOrGz3+MR2fzhkjWaX11yQM=",
-      "dev": true,
-      "requires": {
-        "minimist": "0.0.8"
-      }
+      "dev": true
     },
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
-      "dev": true
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -5963,19 +4065,6 @@
       "resolved": "https://registry.npmjs.org/nanomatch/-/nanomatch-1.2.7.tgz",
       "integrity": "sha512-/5ldsnyurvEw7wNpxLFgjVvBLMta43niEYOy0CJ4ntcYSbx6bugRUTQeFb4BR/WanEL1o3aQgHuVLHQaB6tOqg==",
       "dev": true,
-      "requires": {
-        "arr-diff": "4.0.0",
-        "array-unique": "0.3.2",
-        "define-property": "1.0.0",
-        "extend-shallow": "2.0.1",
-        "fragment-cache": "0.2.1",
-        "is-odd": "1.0.0",
-        "kind-of": "5.1.0",
-        "object.pick": "1.3.0",
-        "regex-not": "1.0.0",
-        "snapdragon": "0.8.1",
-        "to-regex": "3.0.1"
-      },
       "dependencies": {
         "arr-diff": {
           "version": "4.0.0",
@@ -6007,102 +4096,43 @@
       "version": "1.2.5",
       "resolved": "https://registry.npmjs.org/nise/-/nise-1.2.5.tgz",
       "integrity": "sha512-Es4hGuq3lpip5PckrB+Qpuma282M0UJANJ+jxAgI+0wWTL9X6MtNv+M385JgqsAE8hv6NvD3lv8CQtXgEnvlpQ==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/formatio": "2.0.0",
-        "just-extend": "1.1.27",
-        "lolex": "2.3.2",
-        "path-to-regexp": "1.7.0",
-        "text-encoding": "0.6.4"
-      }
+      "dev": true
     },
     "node-fetch": {
       "version": "1.7.3",
       "resolved": "https://registry.npmjs.org/node-fetch/-/node-fetch-1.7.3.tgz",
       "integrity": "sha512-NhZ4CsKx7cYm2vSrBAr2PvFOe6sWDf0UYLRqA6svUYg7+/TSfVAu49jYC4BvQ4Sms9SZgdqGBgroqfDhJdTyKQ==",
-      "dev": true,
-      "requires": {
-        "encoding": "0.1.12",
-        "is-stream": "1.1.0"
-      }
+      "dev": true
     },
     "node-libs-browser": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/node-libs-browser/-/node-libs-browser-2.1.0.tgz",
       "integrity": "sha512-5AzFzdoIMb89hBGMZglEegffzgRg+ZFoUmisQ8HI4j1KDdpx13J0taNp2y9xPbur6W61gepGDDotGBVQ7mfUCg==",
-      "dev": true,
-      "requires": {
-        "assert": "1.4.1",
-        "browserify-zlib": "0.2.0",
-        "buffer": "4.9.1",
-        "console-browserify": "1.1.0",
-        "constants-browserify": "1.0.0",
-        "crypto-browserify": "3.12.0",
-        "domain-browser": "1.2.0",
-        "events": "1.1.1",
-        "https-browserify": "1.0.0",
-        "os-browserify": "0.3.0",
-        "path-browserify": "0.0.0",
-        "process": "0.11.10",
-        "punycode": "1.4.1",
-        "querystring-es3": "0.2.1",
-        "readable-stream": "2.3.4",
-        "stream-browserify": "2.0.1",
-        "stream-http": "2.8.0",
-        "string_decoder": "1.0.3",
-        "timers-browserify": "2.0.6",
-        "tty-browserify": "0.0.0",
-        "url": "0.11.0",
-        "util": "0.10.3",
-        "vm-browserify": "0.0.4"
-      }
+      "dev": true
     },
     "normalize-package-data": {
       "version": "2.4.0",
       "resolved": "https://registry.npmjs.org/normalize-package-data/-/normalize-package-data-2.4.0.tgz",
       "integrity": "sha512-9jjUFbTPfEy3R/ad/2oNbKtW9Hgovl5O1FvFWKkKblNXoN/Oou6+9+KKohPK13Yc3/TyunyWhJp6gvRNR/PPAw==",
-      "dev": true,
-      "requires": {
-        "hosted-git-info": "2.5.0",
-        "is-builtin-module": "1.0.0",
-        "semver": "5.5.0",
-        "validate-npm-package-license": "3.0.1"
-      }
+      "dev": true
     },
     "normalize-path": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/normalize-path/-/normalize-path-2.1.1.tgz",
       "integrity": "sha1-GrKLVW4Zg2Oowab35vogE3/mrtk=",
-      "dev": true,
-      "requires": {
-        "remove-trailing-separator": "1.1.0"
-      }
+      "dev": true
     },
     "npm-run-all": {
       "version": "4.1.2",
       "resolved": "https://registry.npmjs.org/npm-run-all/-/npm-run-all-4.1.2.tgz",
       "integrity": "sha512-Z2aRlajMK4SQ8u19ZA75NZZu7wupfCNQWdYosIi8S6FgBdGf/8Y6Hgyjdc8zU2cYmIRVCx1nM80tJPkdEd+UYg==",
       "dev": true,
-      "requires": {
-        "ansi-styles": "3.2.0",
-        "chalk": "2.3.1",
-        "cross-spawn": "5.1.0",
-        "memorystream": "0.3.1",
-        "minimatch": "3.0.4",
-        "ps-tree": "1.1.0",
-        "read-pkg": "3.0.0",
-        "shell-quote": "1.6.1",
-        "string.prototype.padend": "3.0.0"
-      },
       "dependencies": {
         "ansi-styles": {
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-3.2.0.tgz",
           "integrity": "sha512-NnSOmMEYtVR2JVMIGTzynRkkaxtiq1xnFBcdQD/DnNCYPoEPsVJhM98BDyaoNOQIi7p4okdi3E27eN7GQbsUug==",
-          "dev": true,
-          "requires": {
-            "color-convert": "1.9.1"
-          }
+          "dev": true
         }
       }
     },
@@ -6110,10 +4140,7 @@
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/npm-run-path/-/npm-run-path-2.0.2.tgz",
       "integrity": "sha1-NakjLfo11wZ7TLLd8jV7GHFTbF8=",
-      "dev": true,
-      "requires": {
-        "path-key": "2.0.1"
-      }
+      "dev": true
     },
     "number-is-nan": {
       "version": "1.0.1",
@@ -6132,49 +4159,30 @@
       "resolved": "https://registry.npmjs.org/object-copy/-/object-copy-0.1.0.tgz",
       "integrity": "sha1-fn2Fi3gb18mRpBupde04EnVOmYw=",
       "dev": true,
-      "requires": {
-        "copy-descriptor": "0.1.1",
-        "define-property": "0.2.5",
-        "kind-of": "3.2.2"
-      },
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
+          "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
+          "dev": true
         },
         "is-data-descriptor": {
           "version": "0.1.4",
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
+          "dev": true
         },
         "is-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
           "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          },
           "dependencies": {
             "kind-of": {
               "version": "5.1.0",
@@ -6197,9 +4205,6 @@
       "resolved": "https://registry.npmjs.org/object-visit/-/object-visit-1.0.1.tgz",
       "integrity": "sha1-95xEk68MU3e1n+OdOV5BBC3QRbs=",
       "dev": true,
-      "requires": {
-        "isobject": "3.0.1"
-      },
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
@@ -6213,20 +4218,13 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/object.omit/-/object.omit-2.0.1.tgz",
       "integrity": "sha1-Gpx0SCnznbuFjHbKNXmuKlTr0fo=",
-      "dev": true,
-      "requires": {
-        "for-own": "0.1.5",
-        "is-extendable": "0.1.1"
-      }
+      "dev": true
     },
     "object.pick": {
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/object.pick/-/object.pick-1.3.0.tgz",
       "integrity": "sha1-h6EKxMFpS9Lhy/U1kaZhQftd10c=",
       "dev": true,
-      "requires": {
-        "isobject": "3.0.1"
-      },
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
@@ -6240,33 +4238,19 @@
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/once/-/once-1.4.0.tgz",
       "integrity": "sha1-WDsap3WWHUsROsF9nFC6753Xa9E=",
-      "dev": true,
-      "requires": {
-        "wrappy": "1.0.2"
-      }
+      "dev": true
     },
     "onetime": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/onetime/-/onetime-2.0.1.tgz",
       "integrity": "sha1-BnQoIw/WdEOyeUsiu6UotoZ5YtQ=",
-      "dev": true,
-      "requires": {
-        "mimic-fn": "1.2.0"
-      }
+      "dev": true
     },
     "optionator": {
       "version": "0.8.2",
       "resolved": "https://registry.npmjs.org/optionator/-/optionator-0.8.2.tgz",
       "integrity": "sha1-NkxeQJ0/TWMB1sC0wFu6UBgK62Q=",
-      "dev": true,
-      "requires": {
-        "deep-is": "0.1.3",
-        "fast-levenshtein": "2.0.6",
-        "levn": "0.3.0",
-        "prelude-ls": "1.1.2",
-        "type-check": "0.3.2",
-        "wordwrap": "1.0.0"
-      }
+      "dev": true
     },
     "optjs": {
       "version": "3.2.2",
@@ -6290,12 +4274,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-2.1.0.tgz",
       "integrity": "sha512-3sslG3zJbEYcaC4YVAvDorjGxc7tv6KVATnLPZONiljsUncvihe9BQoVCEs0RZ1kmf4Hk9OBqlZfJZWI4GanKA==",
-      "dev": true,
-      "requires": {
-        "execa": "0.7.0",
-        "lcid": "1.0.0",
-        "mem": "1.1.0"
-      }
+      "dev": true
     },
     "os-tmpdir": {
       "version": "1.0.2",
@@ -6307,12 +4286,7 @@
       "version": "1.1.2",
       "resolved": "https://registry.npmjs.org/output-file-sync/-/output-file-sync-1.1.2.tgz",
       "integrity": "sha1-0KM+7+YaIF+suQCS6CZZjVJFznY=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "mkdirp": "0.5.1",
-        "object-assign": "4.1.1"
-      }
+      "dev": true
     },
     "p-finally": {
       "version": "1.0.0",
@@ -6324,19 +4298,13 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/p-limit/-/p-limit-1.2.0.tgz",
       "integrity": "sha512-Y/OtIaXtUPr4/YpMv1pCL5L5ed0rumAaAeBSj12F+bSlMdys7i8oQF/GUJmfpTS/QoaRrS/k6pma29haJpsMng==",
-      "dev": true,
-      "requires": {
-        "p-try": "1.0.0"
-      }
+      "dev": true
     },
     "p-locate": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/p-locate/-/p-locate-2.0.0.tgz",
       "integrity": "sha1-IKAQOyIqcMj9OcwuWAaA893l7EM=",
-      "dev": true,
-      "requires": {
-        "p-limit": "1.2.0"
-      }
+      "dev": true
     },
     "p-map": {
       "version": "1.2.0",
@@ -6354,13 +4322,7 @@
       "version": "4.0.1",
       "resolved": "https://registry.npmjs.org/package-json/-/package-json-4.0.1.tgz",
       "integrity": "sha1-iGmgQBJTZhxMTKPabCEh7VVfXu0=",
-      "dev": true,
-      "requires": {
-        "got": "6.7.1",
-        "registry-auth-token": "3.3.2",
-        "registry-url": "3.1.0",
-        "semver": "5.5.0"
-      }
+      "dev": true
     },
     "pako": {
       "version": "1.0.6",
@@ -6372,36 +4334,19 @@
       "version": "5.1.0",
       "resolved": "https://registry.npmjs.org/parse-asn1/-/parse-asn1-5.1.0.tgz",
       "integrity": "sha1-N8T5t+06tlx0gXtfJICTf7+XxxI=",
-      "dev": true,
-      "requires": {
-        "asn1.js": "4.10.1",
-        "browserify-aes": "1.1.1",
-        "create-hash": "1.1.3",
-        "evp_bytestokey": "1.0.3",
-        "pbkdf2": "3.0.14"
-      }
+      "dev": true
     },
     "parse-glob": {
       "version": "3.0.4",
       "resolved": "https://registry.npmjs.org/parse-glob/-/parse-glob-3.0.4.tgz",
       "integrity": "sha1-ssN2z7EfNVE7rdFz7wu246OIORw=",
-      "dev": true,
-      "requires": {
-        "glob-base": "0.3.0",
-        "is-dotfile": "1.0.3",
-        "is-extglob": "1.0.0",
-        "is-glob": "2.0.1"
-      }
+      "dev": true
     },
     "parse-json": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-4.0.0.tgz",
       "integrity": "sha1-vjX1Qlvh9/bHRxhPmKeIy5lHfuA=",
-      "dev": true,
-      "requires": {
-        "error-ex": "1.3.1",
-        "json-parse-better-errors": "1.0.1"
-      }
+      "dev": true
     },
     "parse-passwd": {
       "version": "1.0.0",
@@ -6456,9 +4401,6 @@
       "resolved": "https://registry.npmjs.org/path-to-regexp/-/path-to-regexp-1.7.0.tgz",
       "integrity": "sha1-Wf3g9DW62suhA6hOnTvGTpa5k30=",
       "dev": true,
-      "requires": {
-        "isarray": "0.0.1"
-      },
       "dependencies": {
         "isarray": {
           "version": "0.0.1",
@@ -6473,9 +4415,6 @@
       "resolved": "https://registry.npmjs.org/path-type/-/path-type-3.0.0.tgz",
       "integrity": "sha512-T2ZUsdZFHgA3u4e5PfPbjd7HDDpxPnQb5jN0SrDsjNSuVXHJqtwTnWqG0B1jZrgmJ/7lj1EmVIByWt1gxGkWvg==",
       "dev": true,
-      "requires": {
-        "pify": "3.0.0"
-      },
       "dependencies": {
         "pify": {
           "version": "3.0.0",
@@ -6489,23 +4428,13 @@
       "version": "0.0.11",
       "resolved": "https://registry.npmjs.org/pause-stream/-/pause-stream-0.0.11.tgz",
       "integrity": "sha1-/lo0sMvOErWqaitAPuLnO2AvFEU=",
-      "dev": true,
-      "requires": {
-        "through": "2.3.8"
-      }
+      "dev": true
     },
     "pbkdf2": {
       "version": "3.0.14",
       "resolved": "https://registry.npmjs.org/pbkdf2/-/pbkdf2-3.0.14.tgz",
       "integrity": "sha512-gjsZW9O34fm0R7PaLHRJmLLVfSoesxztjPjE9o6R+qtVJij90ltg1joIovN9GKrRW3t1PzhDDG3UMEMFfZ+1wA==",
-      "dev": true,
-      "requires": {
-        "create-hash": "1.1.3",
-        "create-hmac": "1.1.6",
-        "ripemd160": "2.0.1",
-        "safe-buffer": "5.1.1",
-        "sha.js": "2.4.10"
-      }
+      "dev": true
     },
     "pify": {
       "version": "2.3.0",
@@ -6523,38 +4452,25 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/pinkie-promise/-/pinkie-promise-2.0.1.tgz",
       "integrity": "sha1-ITXW36ejWMBprJsXh3YogihFD/o=",
-      "dev": true,
-      "requires": {
-        "pinkie": "2.0.4"
-      }
+      "dev": true
     },
     "pkg-dir": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/pkg-dir/-/pkg-dir-1.0.0.tgz",
       "integrity": "sha1-ektQio1bstYp1EcFb/TpyTFM89Q=",
       "dev": true,
-      "requires": {
-        "find-up": "1.1.2"
-      },
       "dependencies": {
         "find-up": {
           "version": "1.1.2",
           "resolved": "https://registry.npmjs.org/find-up/-/find-up-1.1.2.tgz",
           "integrity": "sha1-ay6YIrGizgpgq2TWEOzK1TyyTQ8=",
-          "dev": true,
-          "requires": {
-            "path-exists": "2.1.0",
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         },
         "path-exists": {
           "version": "2.1.0",
           "resolved": "https://registry.npmjs.org/path-exists/-/path-exists-2.1.0.tgz",
           "integrity": "sha1-D+tsZPD8UY2adU3V77YscCJ2H0s=",
-          "dev": true,
-          "requires": {
-            "pinkie-promise": "2.0.1"
-          }
+          "dev": true
         }
       }
     },
@@ -6623,12 +4539,6 @@
       "resolved": "https://registry.npmjs.org/protobufjs/-/protobufjs-5.0.2.tgz",
       "integrity": "sha1-WXSNfc8D0tsiwT2p/rAk4Wq4DJE=",
       "dev": true,
-      "requires": {
-        "ascli": "1.0.1",
-        "bytebuffer": "5.0.1",
-        "glob": "7.1.2",
-        "yargs": "3.32.0"
-      },
       "dependencies": {
         "camelcase": {
           "version": "2.1.1",
@@ -6640,50 +4550,31 @@
           "version": "3.2.0",
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
-          "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          }
+          "dev": true
         },
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "dev": true
         },
         "os-locale": {
           "version": "1.4.0",
           "resolved": "https://registry.npmjs.org/os-locale/-/os-locale-1.4.0.tgz",
           "integrity": "sha1-IPnxeuKe00XoveWDsT0gCYA8FNk=",
-          "dev": true,
-          "requires": {
-            "lcid": "1.0.0"
-          }
+          "dev": true
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+          "dev": true
         },
         "window-size": {
           "version": "0.1.4",
@@ -6695,16 +4586,7 @@
           "version": "3.32.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.32.0.tgz",
           "integrity": "sha1-AwiOnr+edWtpdRYR0qXvWRSCyZU=",
-          "dev": true,
-          "requires": {
-            "camelcase": "2.1.1",
-            "cliui": "3.2.0",
-            "decamelize": "1.2.0",
-            "os-locale": "1.4.0",
-            "string-width": "1.0.2",
-            "window-size": "0.1.4",
-            "y18n": "3.2.1"
-          }
+          "dev": true
         }
       }
     },
@@ -6718,10 +4600,7 @@
       "version": "1.1.0",
       "resolved": "https://registry.npmjs.org/ps-tree/-/ps-tree-1.1.0.tgz",
       "integrity": "sha1-tCGyQUDWID8e08dplrRCewjowBQ=",
-      "dev": true,
-      "requires": {
-        "event-stream": "3.3.4"
-      }
+      "dev": true
     },
     "pseudomap": {
       "version": "1.0.2",
@@ -6733,14 +4612,7 @@
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/public-encrypt/-/public-encrypt-4.0.0.tgz",
       "integrity": "sha1-OfaZ86RlYN1eusvKaTyvfGXBjMY=",
-      "dev": true,
-      "requires": {
-        "bn.js": "4.11.8",
-        "browserify-rsa": "4.0.1",
-        "create-hash": "1.1.3",
-        "parse-asn1": "5.1.0",
-        "randombytes": "2.0.6"
-      }
+      "dev": true
     },
     "punycode": {
       "version": "1.4.1",
@@ -6764,45 +4636,25 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/qunit/-/qunit-2.5.0.tgz",
       "integrity": "sha512-GVvRr8ISFMs4SkTWFsaUzMBs7QEuiXVT4orlFgyHkmeXO1ijlDkhW6ecPri4urXiE4BUXEULJAtFlV1MWgg4Uw==",
-      "dev": true,
-      "requires": {
-        "chokidar": "1.7.0",
-        "commander": "2.12.2",
-        "exists-stat": "1.0.0",
-        "findup-sync": "2.0.0",
-        "js-reporters": "1.2.1",
-        "resolve": "1.5.0",
-        "shelljs": "0.2.6",
-        "walk-sync": "0.3.2"
-      }
+      "dev": true
     },
     "randomatic": {
       "version": "1.1.7",
       "resolved": "https://registry.npmjs.org/randomatic/-/randomatic-1.1.7.tgz",
       "integrity": "sha512-D5JUjPyJbaJDkuAazpVnSfVkLlpeO3wDlPROTMLGKG1zMFNFRgrciKo1ltz/AzNTkqE0HzDx655QOL51N06how==",
       "dev": true,
-      "requires": {
-        "is-number": "3.0.0",
-        "kind-of": "4.0.0"
-      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "dev": true
             }
           }
         },
@@ -6810,10 +4662,7 @@
           "version": "4.0.0",
           "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-4.0.0.tgz",
           "integrity": "sha1-IIE989cSkosgc3hpGkUGb65y3Vc=",
-          "dev": true,
-          "requires": {
-            "is-buffer": "1.1.6"
-          }
+          "dev": true
         }
       }
     },
@@ -6821,32 +4670,19 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/randombytes/-/randombytes-2.0.6.tgz",
       "integrity": "sha512-CIQ5OFxf4Jou6uOKe9t1AOgqpeU5fd70A8NPdHSGeYXqXsPe6peOwI0cUl88RWZ6sP1vPMV3avd/R6cZ5/sP1A==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
+      "dev": true
     },
     "randomfill": {
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/randomfill/-/randomfill-1.0.4.tgz",
       "integrity": "sha512-87lcbR8+MhcWcUiQ+9e+Rwx8MyR2P7qnt15ynUlbm3TU/fjbgz4GsvfSUDTemtCCtVCqb4ZcEFlyPNTh9bBTLw==",
-      "dev": true,
-      "requires": {
-        "randombytes": "2.0.6",
-        "safe-buffer": "5.1.1"
-      }
+      "dev": true
     },
     "rc": {
       "version": "1.2.8",
       "resolved": "https://registry.npmjs.org/rc/-/rc-1.2.8.tgz",
       "integrity": "sha512-y3bGgqKj3QBdxLbLkomlohkvsA8gdAiUQlSBJnBhfn+BPxg4bc62d8TcBW15wavDfgexCgccckhcZvywyQYPOw==",
       "dev": true,
-      "requires": {
-        "deep-extend": "0.6.0",
-        "ini": "1.3.5",
-        "minimist": "1.2.0",
-        "strip-json-comments": "2.0.1"
-      },
       "dependencies": {
         "minimist": {
           "version": "1.2.0",
@@ -6860,63 +4696,37 @@
       "version": "3.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-3.0.0.tgz",
       "integrity": "sha1-nLxoaXj+5l0WwA4rGcI3/Pbjg4k=",
-      "dev": true,
-      "requires": {
-        "load-json-file": "4.0.0",
-        "normalize-package-data": "2.4.0",
-        "path-type": "3.0.0"
-      }
+      "dev": true
     },
     "read-pkg-up": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/read-pkg-up/-/read-pkg-up-2.0.0.tgz",
       "integrity": "sha1-a3KoBImE4MQeeVEP1en6mbO1Sb4=",
       "dev": true,
-      "requires": {
-        "find-up": "2.1.0",
-        "read-pkg": "2.0.0"
-      },
       "dependencies": {
         "load-json-file": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/load-json-file/-/load-json-file-2.0.0.tgz",
           "integrity": "sha1-eUfkIUmvgNaWy/eXvKq8/h/inKg=",
-          "dev": true,
-          "requires": {
-            "graceful-fs": "4.1.11",
-            "parse-json": "2.2.0",
-            "pify": "2.3.0",
-            "strip-bom": "3.0.0"
-          }
+          "dev": true
         },
         "parse-json": {
           "version": "2.2.0",
           "resolved": "https://registry.npmjs.org/parse-json/-/parse-json-2.2.0.tgz",
           "integrity": "sha1-9ID0BDTvgHQfhGkJn43qGPVaTck=",
-          "dev": true,
-          "requires": {
-            "error-ex": "1.3.1"
-          }
+          "dev": true
         },
         "path-type": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/path-type/-/path-type-2.0.0.tgz",
           "integrity": "sha1-8BLMuEFbcJb8LaoQVMPXI4lZTHM=",
-          "dev": true,
-          "requires": {
-            "pify": "2.3.0"
-          }
+          "dev": true
         },
         "read-pkg": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/read-pkg/-/read-pkg-2.0.0.tgz",
           "integrity": "sha1-jvHAYjxqbbDcZxPEv6xGMysjaPg=",
-          "dev": true,
-          "requires": {
-            "load-json-file": "2.0.0",
-            "normalize-package-data": "2.4.0",
-            "path-type": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -6924,38 +4734,19 @@
       "version": "2.3.4",
       "resolved": "https://registry.npmjs.org/readable-stream/-/readable-stream-2.3.4.tgz",
       "integrity": "sha512-vuYxeWYM+fde14+rajzqgeohAI7YoJcHE7kXDAc4Nk0EbuKnJfqtY9YtRkLo/tqkuF7MsBQRhPnPeyjYITp3ZQ==",
-      "dev": true,
-      "requires": {
-        "core-util-is": "1.0.2",
-        "inherits": "2.0.3",
-        "isarray": "1.0.0",
-        "process-nextick-args": "2.0.0",
-        "safe-buffer": "5.1.1",
-        "string_decoder": "1.0.3",
-        "util-deprecate": "1.0.2"
-      }
+      "dev": true
     },
     "readdirp": {
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/readdirp/-/readdirp-2.1.0.tgz",
       "integrity": "sha1-TtCtBg3zBzMAxIRANz9y0cxkLXg=",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "minimatch": "3.0.4",
-        "readable-stream": "2.3.4",
-        "set-immediate-shim": "1.0.1"
-      }
+      "dev": true
     },
     "redent": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/redent/-/redent-1.0.0.tgz",
       "integrity": "sha1-z5Fqsf1fHxbfsggi3W7H9zDCr94=",
-      "dev": true,
-      "requires": {
-        "indent-string": "2.1.0",
-        "strip-indent": "1.0.1"
-      }
+      "dev": true
     },
     "regenerate": {
       "version": "1.4.0",
@@ -6966,67 +4757,43 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
-      "dev": true
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
     },
     "regenerator-transform": {
       "version": "0.10.1",
       "resolved": "https://registry.npmjs.org/regenerator-transform/-/regenerator-transform-0.10.1.tgz",
       "integrity": "sha512-PJepbvDbuK1xgIgnau7Y90cwaAmO/LCLMI2mPvaXq2heGMR3aWW5/BQvYrhJ8jgmQjXewXvBjzfqKcVOmhjZ6Q==",
-      "dev": true,
-      "requires": {
-        "babel-runtime": "6.26.0",
-        "babel-types": "6.26.0",
-        "private": "0.1.8"
-      }
+      "dev": true
     },
     "regex-cache": {
       "version": "0.4.4",
       "resolved": "https://registry.npmjs.org/regex-cache/-/regex-cache-0.4.4.tgz",
       "integrity": "sha512-nVIZwtCjkC9YgvWkpM55B5rBhBYRZhAaJbgcFYXXsHnbZ9UZI9nnVWYZpBlCqv9ho2eZryPnWrZGsOdPwVWXWQ==",
-      "dev": true,
-      "requires": {
-        "is-equal-shallow": "0.1.3"
-      }
+      "dev": true
     },
     "regex-not": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/regex-not/-/regex-not-1.0.0.tgz",
       "integrity": "sha1-Qvg+OXcWIt+CawKvF2Ul1qXxV/k=",
-      "dev": true,
-      "requires": {
-        "extend-shallow": "2.0.1"
-      }
+      "dev": true
     },
     "regexpu-core": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/regexpu-core/-/regexpu-core-2.0.0.tgz",
       "integrity": "sha1-SdA4g3uNz4v6W5pCE5k45uoq4kA=",
-      "dev": true,
-      "requires": {
-        "regenerate": "1.4.0",
-        "regjsgen": "0.2.0",
-        "regjsparser": "0.1.5"
-      }
+      "dev": true
     },
     "registry-auth-token": {
       "version": "3.3.2",
       "resolved": "https://registry.npmjs.org/registry-auth-token/-/registry-auth-token-3.3.2.tgz",
       "integrity": "sha512-JL39c60XlzCVgNrO+qq68FoNb56w/m7JYvGR2jT5iR1xBrUA3Mfx5Twk5rqTThPmQKMWydGmq8oFtDlxfrmxnQ==",
-      "dev": true,
-      "requires": {
-        "rc": "1.2.8",
-        "safe-buffer": "5.1.1"
-      }
+      "dev": true
     },
     "registry-url": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/registry-url/-/registry-url-3.1.0.tgz",
       "integrity": "sha1-PU74cPc93h138M+aOBQyRE4XSUI=",
-      "dev": true,
-      "requires": {
-        "rc": "1.2.8"
-      }
+      "dev": true
     },
     "regjsgen": {
       "version": "0.2.0",
@@ -7039,9 +4806,6 @@
       "resolved": "https://registry.npmjs.org/regjsparser/-/regjsparser-0.1.5.tgz",
       "integrity": "sha1-fuj4Tcb6eS0/0K4ijSS9lJ6tIFw=",
       "dev": true,
-      "requires": {
-        "jsesc": "0.5.0"
-      },
       "dependencies": {
         "jsesc": {
           "version": "0.5.0",
@@ -7073,10 +4837,7 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/repeating/-/repeating-2.0.1.tgz",
       "integrity": "sha1-UhTFOpJtNVJwdSf7q0FdvAjQbdo=",
-      "dev": true,
-      "requires": {
-        "is-finite": "1.0.2"
-      }
+      "dev": true
     },
     "require-directory": {
       "version": "2.1.1",
@@ -7094,30 +4855,19 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/require-uncached/-/require-uncached-1.0.3.tgz",
       "integrity": "sha1-Tg1W1slmL9MeQwEcS5WqSZVUIdM=",
-      "dev": true,
-      "requires": {
-        "caller-path": "0.1.0",
-        "resolve-from": "1.0.1"
-      }
+      "dev": true
     },
     "resolve": {
       "version": "1.5.0",
       "resolved": "https://registry.npmjs.org/resolve/-/resolve-1.5.0.tgz",
       "integrity": "sha512-hgoSGrc3pjzAPHNBg+KnFcK2HwlHTs/YrAGUr6qgTVUZmXv1UEXXl0bZNBKMA9fud6lRYFdPGz0xXxycPzmmiw==",
-      "dev": true,
-      "requires": {
-        "path-parse": "1.0.5"
-      }
+      "dev": true
     },
     "resolve-dir": {
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/resolve-dir/-/resolve-dir-1.0.1.tgz",
       "integrity": "sha1-eaQGRMNivoLybv/nOcm7U4IEb0M=",
-      "dev": true,
-      "requires": {
-        "expand-tilde": "2.0.2",
-        "global-modules": "1.0.0"
-      }
+      "dev": true
     },
     "resolve-from": {
       "version": "1.0.1",
@@ -7135,48 +4885,31 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/restore-cursor/-/restore-cursor-2.0.0.tgz",
       "integrity": "sha1-n37ih/gv0ybU/RYpI9YhKe7g368=",
-      "dev": true,
-      "requires": {
-        "onetime": "2.0.1",
-        "signal-exit": "3.0.2"
-      }
+      "dev": true
     },
     "right-align": {
       "version": "0.1.3",
       "resolved": "https://registry.npmjs.org/right-align/-/right-align-0.1.3.tgz",
       "integrity": "sha1-YTObci/mo1FWiSENJOFMlhSGE+8=",
-      "dev": true,
-      "requires": {
-        "align-text": "0.1.4"
-      }
+      "dev": true
     },
     "rimraf": {
       "version": "2.6.2",
       "resolved": "https://registry.npmjs.org/rimraf/-/rimraf-2.6.2.tgz",
       "integrity": "sha512-lreewLK/BlghmxtfH36YYVg1i8IAce4TI7oao75I1g245+6BctqTVQiBP3YUJ9C6DQOXJmkYR9X9fCLtCOJc5w==",
-      "dev": true,
-      "requires": {
-        "glob": "7.1.2"
-      }
+      "dev": true
     },
     "ripemd160": {
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/ripemd160/-/ripemd160-2.0.1.tgz",
       "integrity": "sha1-D0WEKVxTo2KK9+bXmsohzlfRxuc=",
-      "dev": true,
-      "requires": {
-        "hash-base": "2.0.2",
-        "inherits": "2.0.3"
-      }
+      "dev": true
     },
     "run-async": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/run-async/-/run-async-2.3.0.tgz",
       "integrity": "sha1-A3GrSuC91yDUFm19/aZP96RFpsA=",
-      "dev": true,
-      "requires": {
-        "is-promise": "2.1.0"
-      }
+      "dev": true
     },
     "rx-lite": {
       "version": "4.0.8",
@@ -7188,10 +4921,7 @@
       "version": "4.0.8",
       "resolved": "https://registry.npmjs.org/rx-lite-aggregates/-/rx-lite-aggregates-4.0.8.tgz",
       "integrity": "sha1-dTuHqJoRyVRnxKwWJsTvxOBcZ74=",
-      "dev": true,
-      "requires": {
-        "rx-lite": "4.0.8"
-      }
+      "dev": true
     },
     "safe-buffer": {
       "version": "5.1.1",
@@ -7215,10 +4945,7 @@
       "version": "2.1.0",
       "resolved": "https://registry.npmjs.org/semver-diff/-/semver-diff-2.1.0.tgz",
       "integrity": "sha1-S7uEN8jTfksM8aaP1ybsbWRdbTY=",
-      "dev": true,
-      "requires": {
-        "semver": "5.5.0"
-      }
+      "dev": true
     },
     "set-blocking": {
       "version": "2.0.0",
@@ -7230,10 +4957,7 @@
       "version": "0.1.0",
       "resolved": "https://registry.npmjs.org/set-getter/-/set-getter-0.1.0.tgz",
       "integrity": "sha1-12nBgsnVpR9AkUXy+6guXoboA3Y=",
-      "dev": true,
-      "requires": {
-        "to-object-path": "0.3.0"
-      }
+      "dev": true
     },
     "set-immediate-shim": {
       "version": "1.0.1",
@@ -7245,13 +4969,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/set-value/-/set-value-2.0.0.tgz",
       "integrity": "sha512-hw0yxk9GT/Hr5yJEYnHNKYXkIA8mVJgd9ditYZCe16ZczcaELYYcfvaXesNACk2O8O0nTiPQcQhGUQj8JLzeeg==",
-      "dev": true,
-      "requires": {
-        "extend-shallow": "2.0.1",
-        "is-extendable": "0.1.1",
-        "is-plain-object": "2.0.4",
-        "split-string": "3.1.0"
-      }
+      "dev": true
     },
     "setimmediate": {
       "version": "1.0.5",
@@ -7263,20 +4981,13 @@
       "version": "2.4.10",
       "resolved": "https://registry.npmjs.org/sha.js/-/sha.js-2.4.10.tgz",
       "integrity": "sha512-vnwmrFDlOExK4Nm16J2KMWHLrp14lBrjxMxBJpu++EnsuBmpiYaM/MEs46Vxxm/4FvdP5yTwuCTO9it5FSjrqA==",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "safe-buffer": "5.1.1"
-      }
+      "dev": true
     },
     "shebang-command": {
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/shebang-command/-/shebang-command-1.2.0.tgz",
       "integrity": "sha1-RKrGW2lbAzmJaMOfNj/uXer98eo=",
-      "dev": true,
-      "requires": {
-        "shebang-regex": "1.0.0"
-      }
+      "dev": true
     },
     "shebang-regex": {
       "version": "1.0.0",
@@ -7288,13 +4999,7 @@
       "version": "1.6.1",
       "resolved": "https://registry.npmjs.org/shell-quote/-/shell-quote-1.6.1.tgz",
       "integrity": "sha1-9HgZSczkAmlxJ0MOo7PFR29IF2c=",
-      "dev": true,
-      "requires": {
-        "array-filter": "0.0.1",
-        "array-map": "0.0.0",
-        "array-reduce": "0.0.0",
-        "jsonify": "0.0.0"
-      }
+      "dev": true
     },
     "shelljs": {
       "version": "0.2.6",
@@ -7312,16 +5017,7 @@
       "version": "4.3.0",
       "resolved": "https://registry.npmjs.org/sinon/-/sinon-4.3.0.tgz",
       "integrity": "sha512-pmf05hFgEZUS52AGJcsVjOjqAyJW2yo14cOwVYvzCyw7+inv06YXkLyW75WG6X6p951lzkoKh51L2sNbR9CDvw==",
-      "dev": true,
-      "requires": {
-        "@sinonjs/formatio": "2.0.0",
-        "diff": "3.4.0",
-        "lodash.get": "4.4.2",
-        "lolex": "2.3.2",
-        "nise": "1.2.5",
-        "supports-color": "5.2.0",
-        "type-detect": "4.0.8"
-      }
+      "dev": true
     },
     "slash": {
       "version": "1.0.0",
@@ -7333,53 +5029,31 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/slice-ansi/-/slice-ansi-1.0.0.tgz",
       "integrity": "sha512-POqxBK6Lb3q6s047D/XsDVNPnF9Dl8JSaqe9h9lURl0OdNqy/ujDrOiIHtsqXMGbWWTIomRzAMaTyawAU//Reg==",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0"
-      }
+      "dev": true
     },
     "snapdragon": {
       "version": "0.8.1",
       "resolved": "https://registry.npmjs.org/snapdragon/-/snapdragon-0.8.1.tgz",
       "integrity": "sha1-4StUh/re0+PeoKyR6UAL91tAE3A=",
       "dev": true,
-      "requires": {
-        "base": "0.11.2",
-        "debug": "2.6.9",
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "map-cache": "0.2.2",
-        "source-map": "0.5.7",
-        "source-map-resolve": "0.5.1",
-        "use": "2.0.2"
-      },
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
+          "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "dev": true
             }
           }
         },
@@ -7388,18 +5062,12 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "dev": true
             }
           }
         },
@@ -7407,12 +5075,7 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
+          "dev": true
         },
         "kind-of": {
           "version": "5.1.0",
@@ -7427,11 +5090,6 @@
       "resolved": "https://registry.npmjs.org/snapdragon-node/-/snapdragon-node-2.1.1.tgz",
       "integrity": "sha512-O27l4xaMYt/RSQ5TR3vpWCAB5Kb/czIcqUFOM/C4fYcLnbZUc1PkjTAMjof2pBWaSTwOUd6qUHcFGVGj7aIwnw==",
       "dev": true,
-      "requires": {
-        "define-property": "1.0.0",
-        "isobject": "3.0.1",
-        "snapdragon-util": "3.0.1"
-      },
       "dependencies": {
         "isobject": {
           "version": "3.0.1",
@@ -7445,10 +5103,7 @@
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/snapdragon-util/-/snapdragon-util-3.0.1.tgz",
       "integrity": "sha512-mbKkMdQKsjX4BAL4bRYTj21edOf8cN7XHdYUJEe+Zn99hVEYcMvKPct1IqNe7+AZPirn8BCDOQBHQZknqmKlZQ==",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2"
-      }
+      "dev": true
     },
     "source-list-map": {
       "version": "2.0.0",
@@ -7466,23 +5121,13 @@
       "version": "0.5.1",
       "resolved": "https://registry.npmjs.org/source-map-resolve/-/source-map-resolve-0.5.1.tgz",
       "integrity": "sha512-0KW2wvzfxm8NCTb30z0LMNyPqWCdDGE2viwzUaucqJdkTRXtZiSY3I+2A6nVAjmdOy0I4gU8DwnVVGsk9jvP2A==",
-      "dev": true,
-      "requires": {
-        "atob": "2.0.3",
-        "decode-uri-component": "0.2.0",
-        "resolve-url": "0.2.1",
-        "source-map-url": "0.4.0",
-        "urix": "0.1.0"
-      }
+      "dev": true
     },
     "source-map-support": {
       "version": "0.4.18",
       "resolved": "https://registry.npmjs.org/source-map-support/-/source-map-support-0.4.18.tgz",
       "integrity": "sha512-try0/JqxPLF9nOjvSta7tVondkP5dwgyLDjVoyMDlmjugT2lRZ1OfsrYTkCd2hkDnJTKRbO/Rl3orm8vlsUzbA==",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.7"
-      }
+      "dev": true
     },
     "source-map-url": {
       "version": "0.4.0",
@@ -7494,10 +5139,7 @@
       "version": "1.0.2",
       "resolved": "https://registry.npmjs.org/spdx-correct/-/spdx-correct-1.0.2.tgz",
       "integrity": "sha1-SzBz2TP/UfORLwOsVRlJikFQ20A=",
-      "dev": true,
-      "requires": {
-        "spdx-license-ids": "1.2.2"
-      }
+      "dev": true
     },
     "spdx-expression-parse": {
       "version": "1.0.4",
@@ -7515,38 +5157,25 @@
       "version": "0.3.3",
       "resolved": "https://registry.npmjs.org/split/-/split-0.3.3.tgz",
       "integrity": "sha1-zQ7qXmOiEd//frDwkcQTPi0N0o8=",
-      "dev": true,
-      "requires": {
-        "through": "2.3.8"
-      }
+      "dev": true
     },
     "split-string": {
       "version": "3.1.0",
       "resolved": "https://registry.npmjs.org/split-string/-/split-string-3.1.0.tgz",
       "integrity": "sha512-NzNVhJDYpwceVVii8/Hu6DKfD2G+NrQHlS/V/qgv763EYudVwEcMQNxd2lh+0VrUByXN/oJkl5grOhYWvQUYiw==",
       "dev": true,
-      "requires": {
-        "extend-shallow": "3.0.2"
-      },
       "dependencies": {
         "extend-shallow": {
           "version": "3.0.2",
           "resolved": "https://registry.npmjs.org/extend-shallow/-/extend-shallow-3.0.2.tgz",
           "integrity": "sha1-Jqcarwc7OfshJxcnRhMcJwQCjbg=",
-          "dev": true,
-          "requires": {
-            "assign-symbols": "1.0.0",
-            "is-extendable": "1.0.1"
-          }
+          "dev": true
         },
         "is-extendable": {
           "version": "1.0.1",
           "resolved": "https://registry.npmjs.org/is-extendable/-/is-extendable-1.0.1.tgz",
           "integrity": "sha512-arnXMxT1hhoKo9k1LZdmlNyJdDDfy2v0fXjFlmok4+i8ul/6WlbVge9bhM74OpNPQPMGUToDtz+KXa1PneJxOA==",
-          "dev": true,
-          "requires": {
-            "is-plain-object": "2.0.4"
-          }
+          "dev": true
         }
       }
     },
@@ -7561,37 +5190,24 @@
       "resolved": "https://registry.npmjs.org/static-extend/-/static-extend-0.1.2.tgz",
       "integrity": "sha1-YICcOcv/VTNyJv1eC1IPNB8ftcY=",
       "dev": true,
-      "requires": {
-        "define-property": "0.2.5",
-        "object-copy": "0.1.0"
-      },
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
+          "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "dev": true
             }
           }
         },
@@ -7600,18 +5216,12 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "dev": true
             }
           }
         },
@@ -7619,12 +5229,7 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
+          "dev": true
         },
         "kind-of": {
           "version": "5.1.0",
@@ -7638,72 +5243,43 @@
       "version": "2.0.1",
       "resolved": "https://registry.npmjs.org/stream-browserify/-/stream-browserify-2.0.1.tgz",
       "integrity": "sha1-ZiZu5fm9uZQKTkUUyvtDu3Hlyds=",
-      "dev": true,
-      "requires": {
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4"
-      }
+      "dev": true
     },
     "stream-combiner": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/stream-combiner/-/stream-combiner-0.0.4.tgz",
       "integrity": "sha1-TV5DPBhSYd3mI8o/RMWGvPXErRQ=",
-      "dev": true,
-      "requires": {
-        "duplexer": "0.1.1"
-      }
+      "dev": true
     },
     "stream-http": {
       "version": "2.8.0",
       "resolved": "https://registry.npmjs.org/stream-http/-/stream-http-2.8.0.tgz",
       "integrity": "sha512-sZOFxI/5xw058XIRHl4dU3dZ+TTOIGJR78Dvo0oEAejIt4ou27k+3ne1zYmCV+v7UucbxIFQuOgnkTVHh8YPnw==",
-      "dev": true,
-      "requires": {
-        "builtin-status-codes": "3.0.0",
-        "inherits": "2.0.3",
-        "readable-stream": "2.3.4",
-        "to-arraybuffer": "1.0.1",
-        "xtend": "4.0.1"
-      }
-    },
-    "string-width": {
-      "version": "2.1.1",
-      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
-      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
-      "dev": true,
-      "requires": {
-        "is-fullwidth-code-point": "2.0.0",
-        "strip-ansi": "4.0.0"
-      }
-    },
-    "string.prototype.padend": {
-      "version": "3.0.0",
-      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
-      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
-      "dev": true,
-      "requires": {
-        "define-properties": "1.1.2",
-        "es-abstract": "1.10.0",
-        "function-bind": "1.1.1"
-      }
+      "dev": true
     },
     "string_decoder": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/string_decoder/-/string_decoder-1.0.3.tgz",
       "integrity": "sha512-4AH6Z5fzNNBcH+6XDMfA/BTt87skxqJlO0lAh3Dker5zThcAxG6mKz+iGu308UKoPPQ8Dcqx/4JhujzltRa+hQ==",
-      "dev": true,
-      "requires": {
-        "safe-buffer": "5.1.1"
-      }
+      "dev": true
+    },
+    "string-width": {
+      "version": "2.1.1",
+      "resolved": "https://registry.npmjs.org/string-width/-/string-width-2.1.1.tgz",
+      "integrity": "sha512-nOqH59deCq9SRHlxq1Aw85Jnt4w6KvLKqWVik6oA9ZklXLNIOlqg4F2yrT1MVaTjAqvVwdfeZ7w7aCvJD7ugkw==",
+      "dev": true
+    },
+    "string.prototype.padend": {
+      "version": "3.0.0",
+      "resolved": "https://registry.npmjs.org/string.prototype.padend/-/string.prototype.padend-3.0.0.tgz",
+      "integrity": "sha1-86rvfBcZ8XDF6rHDK/eA2W4h8vA=",
+      "dev": true
     },
     "strip-ansi": {
       "version": "4.0.0",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-4.0.0.tgz",
       "integrity": "sha1-qEeQIusaw2iocTibY1JixQXuNo8=",
       "dev": true,
-      "requires": {
-        "ansi-regex": "3.0.0"
-      },
       "dependencies": {
         "ansi-regex": {
           "version": "3.0.0",
@@ -7729,10 +5305,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/strip-indent/-/strip-indent-1.0.1.tgz",
       "integrity": "sha1-DHlipq3vp7vUrDZkYKY4VSrhoKI=",
-      "dev": true,
-      "requires": {
-        "get-stdin": "4.0.1"
-      }
+      "dev": true
     },
     "strip-json-comments": {
       "version": "2.0.1",
@@ -7744,24 +5317,13 @@
       "version": "5.2.0",
       "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-5.2.0.tgz",
       "integrity": "sha512-F39vS48la4YvTZUPVeTqsjsFNrvcMwrV3RLZINsmHo+7djCvuUzSIeXOnZ5hmjef4bajL1dNccN+tg5XAliO5Q==",
-      "dev": true,
-      "requires": {
-        "has-flag": "3.0.0"
-      }
+      "dev": true
     },
     "table": {
       "version": "4.0.2",
       "resolved": "https://registry.npmjs.org/table/-/table-4.0.2.tgz",
       "integrity": "sha512-UUkEAPdSGxtRpiV9ozJ5cMTtYiqz7Ni1OGqLXRCynrvzdtR1p+cfOWe2RJLwvUG8hNanaSRjecIqwOjqeatDsA==",
-      "dev": true,
-      "requires": {
-        "ajv": "5.5.2",
-        "ajv-keywords": "2.1.1",
-        "chalk": "2.3.1",
-        "lodash": "4.17.5",
-        "slice-ansi": "1.0.0",
-        "string-width": "2.1.1"
-      }
+      "dev": true
     },
     "tapable": {
       "version": "0.2.8",
@@ -7773,10 +5335,7 @@
       "version": "1.2.0",
       "resolved": "https://registry.npmjs.org/term-size/-/term-size-1.2.0.tgz",
       "integrity": "sha1-RYuDiH8oj8Vtb/+/rSYuJmOO+mk=",
-      "dev": true,
-      "requires": {
-        "execa": "0.7.0"
-      }
+      "dev": true
     },
     "text-encoding": {
       "version": "0.6.4",
@@ -7806,19 +5365,13 @@
       "version": "2.0.6",
       "resolved": "https://registry.npmjs.org/timers-browserify/-/timers-browserify-2.0.6.tgz",
       "integrity": "sha512-HQ3nbYRAowdVd0ckGFvmJPPCOH/CHleFN/Y0YQCX1DVaB7t+KFvisuyN09fuP8Jtp1CpfSh8O8bMkHbdbPe6Pw==",
-      "dev": true,
-      "requires": {
-        "setimmediate": "1.0.5"
-      }
+      "dev": true
     },
     "tmp": {
       "version": "0.0.33",
       "resolved": "https://registry.npmjs.org/tmp/-/tmp-0.0.33.tgz",
       "integrity": "sha512-jRCJlojKnZ3addtTOjdIqoRuPEKBvNXcGYqzO6zWZX8KfKEpnGY5jfggJQ3EjKuu8D4bJRr0y+cYJFmYbImXGw==",
-      "dev": true,
-      "requires": {
-        "os-tmpdir": "1.0.2"
-      }
+      "dev": true
     },
     "to-arraybuffer": {
       "version": "1.0.1",
@@ -7829,55 +5382,37 @@
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
-      "dev": true
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
     },
     "to-object-path": {
       "version": "0.3.0",
       "resolved": "https://registry.npmjs.org/to-object-path/-/to-object-path-0.3.0.tgz",
       "integrity": "sha1-KXWIt7Dn4KwI4E5nL4XB9JmeF68=",
-      "dev": true,
-      "requires": {
-        "kind-of": "3.2.2"
-      }
+      "dev": true
     },
     "to-regex": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/to-regex/-/to-regex-3.0.1.tgz",
       "integrity": "sha1-FTWL7kosg712N3uh3ASdDxiDeq4=",
       "dev": true,
-      "requires": {
-        "define-property": "0.2.5",
-        "extend-shallow": "2.0.1",
-        "regex-not": "1.0.0"
-      },
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
+          "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "dev": true
             }
           }
         },
@@ -7886,18 +5421,12 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "dev": true
             }
           }
         },
@@ -7905,12 +5434,7 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
+          "dev": true
         },
         "kind-of": {
           "version": "5.1.0",
@@ -7925,19 +5449,12 @@
       "resolved": "https://registry.npmjs.org/to-regex-range/-/to-regex-range-2.1.1.tgz",
       "integrity": "sha1-fIDBe53+vlmeJzZ+DU3VWQFB2zg=",
       "dev": true,
-      "requires": {
-        "is-number": "3.0.0",
-        "repeat-string": "1.6.1"
-      },
       "dependencies": {
         "is-number": {
           "version": "3.0.0",
           "resolved": "https://registry.npmjs.org/is-number/-/is-number-3.0.0.tgz",
           "integrity": "sha1-JP1iAaR4LPUFYcgQJ2r8fRLXEZU=",
-          "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          }
+          "dev": true
         }
       }
     },
@@ -7969,10 +5486,7 @@
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/type-check/-/type-check-0.3.2.tgz",
       "integrity": "sha1-WITKtRLPHTVeP7eE8wgEsrUg23I=",
-      "dev": true,
-      "requires": {
-        "prelude-ls": "1.1.2"
-      }
+      "dev": true
     },
     "type-detect": {
       "version": "4.0.8",
@@ -7991,23 +5505,12 @@
       "resolved": "https://registry.npmjs.org/uglify-js/-/uglify-js-2.8.29.tgz",
       "integrity": "sha1-KcVzMUgFe7Th913zW3qcty5qWd0=",
       "dev": true,
-      "requires": {
-        "source-map": "0.5.7",
-        "uglify-to-browserify": "1.0.2",
-        "yargs": "3.10.0"
-      },
       "dependencies": {
         "yargs": {
           "version": "3.10.0",
           "resolved": "https://registry.npmjs.org/yargs/-/yargs-3.10.0.tgz",
           "integrity": "sha1-9+572FfdfB0tOMDnTvvWgdFDH9E=",
-          "dev": true,
-          "requires": {
-            "camelcase": "1.2.1",
-            "cliui": "2.1.0",
-            "decamelize": "1.2.0",
-            "window-size": "0.1.0"
-          }
+          "dev": true
         }
       }
     },
@@ -8022,36 +5525,19 @@
       "version": "0.4.6",
       "resolved": "https://registry.npmjs.org/uglifyjs-webpack-plugin/-/uglifyjs-webpack-plugin-0.4.6.tgz",
       "integrity": "sha1-uVH0q7a9YX5m9j64kUmOORdj4wk=",
-      "dev": true,
-      "requires": {
-        "source-map": "0.5.7",
-        "uglify-js": "2.8.29",
-        "webpack-sources": "1.1.0"
-      }
+      "dev": true
     },
     "union-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/union-value/-/union-value-1.0.0.tgz",
       "integrity": "sha1-XHHDTLW61dzr4+oM0IIHulqhrqQ=",
       "dev": true,
-      "requires": {
-        "arr-union": "3.1.0",
-        "get-value": "2.0.6",
-        "is-extendable": "0.1.1",
-        "set-value": "0.4.3"
-      },
       "dependencies": {
         "set-value": {
           "version": "0.4.3",
           "resolved": "https://registry.npmjs.org/set-value/-/set-value-0.4.3.tgz",
           "integrity": "sha1-fbCPnT0i3H945Trzw79GZuzfzPE=",
-          "dev": true,
-          "requires": {
-            "extend-shallow": "2.0.1",
-            "is-extendable": "0.1.1",
-            "is-plain-object": "2.0.4",
-            "to-object-path": "0.3.0"
-          }
+          "dev": true
         }
       }
     },
@@ -8059,40 +5545,25 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unique-string/-/unique-string-1.0.0.tgz",
       "integrity": "sha1-nhBXzKhRq7kzmPizOuGHuZyuwRo=",
-      "dev": true,
-      "requires": {
-        "crypto-random-string": "1.0.0"
-      }
+      "dev": true
     },
     "unset-value": {
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/unset-value/-/unset-value-1.0.0.tgz",
       "integrity": "sha1-g3aHP30jNRef+x5vw6jtDfyKtVk=",
       "dev": true,
-      "requires": {
-        "has-value": "0.3.1",
-        "isobject": "3.0.1"
-      },
       "dependencies": {
         "has-value": {
           "version": "0.3.1",
           "resolved": "https://registry.npmjs.org/has-value/-/has-value-0.3.1.tgz",
           "integrity": "sha1-ex9YutpiyoJ+wKIHgCVlSEWZXh8=",
           "dev": true,
-          "requires": {
-            "get-value": "2.0.6",
-            "has-values": "0.1.4",
-            "isobject": "2.1.0"
-          },
           "dependencies": {
             "isobject": {
               "version": "2.1.0",
               "resolved": "https://registry.npmjs.org/isobject/-/isobject-2.1.0.tgz",
               "integrity": "sha1-8GVWEJaj8dou9GJy+BXIQNh+DIk=",
-              "dev": true,
-              "requires": {
-                "isarray": "1.0.0"
-              }
+              "dev": true
             }
           }
         },
@@ -8120,19 +5591,7 @@
       "version": "2.5.0",
       "resolved": "https://registry.npmjs.org/update-notifier/-/update-notifier-2.5.0.tgz",
       "integrity": "sha512-gwMdhgJHGuj/+wHJJs9e6PcCszpxR1b236igrOkUofGhqJuG+amlIKwApH1IW1WWl7ovZxsX49lMBWLxSdm5Dw==",
-      "dev": true,
-      "requires": {
-        "boxen": "1.3.0",
-        "chalk": "2.3.1",
-        "configstore": "3.1.2",
-        "import-lazy": "2.1.0",
-        "is-ci": "1.1.0",
-        "is-installed-globally": "0.1.0",
-        "is-npm": "1.0.0",
-        "latest-version": "3.1.0",
-        "semver-diff": "2.1.0",
-        "xdg-basedir": "3.0.0"
-      }
+      "dev": true
     },
     "urix": {
       "version": "0.1.0",
@@ -8145,10 +5604,6 @@
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.0.tgz",
       "integrity": "sha1-ODjpfPxgUh63PFJajlW/3Z4uKPE=",
       "dev": true,
-      "requires": {
-        "punycode": "1.3.2",
-        "querystring": "0.2.0"
-      },
       "dependencies": {
         "punycode": {
           "version": "1.3.2",
@@ -8162,48 +5617,31 @@
       "version": "1.0.0",
       "resolved": "https://registry.npmjs.org/url-parse-lax/-/url-parse-lax-1.0.0.tgz",
       "integrity": "sha1-evjzA2Rem9eaJy56FKxovAYJ2nM=",
-      "dev": true,
-      "requires": {
-        "prepend-http": "1.0.4"
-      }
+      "dev": true
     },
     "use": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/use/-/use-2.0.2.tgz",
       "integrity": "sha1-riig1y+TvyJCKhii43mZMRLeyOg=",
       "dev": true,
-      "requires": {
-        "define-property": "0.2.5",
-        "isobject": "3.0.1",
-        "lazy-cache": "2.0.2"
-      },
       "dependencies": {
         "define-property": {
           "version": "0.2.5",
           "resolved": "https://registry.npmjs.org/define-property/-/define-property-0.2.5.tgz",
           "integrity": "sha1-w1se+RjsPJkPmlvFe+BKrOxcgRY=",
-          "dev": true,
-          "requires": {
-            "is-descriptor": "0.1.6"
-          }
+          "dev": true
         },
         "is-accessor-descriptor": {
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-accessor-descriptor/-/is-accessor-descriptor-0.1.6.tgz",
           "integrity": "sha1-qeEss66Nh2cn7u84Q/igiXtcmNY=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "dev": true
             }
           }
         },
@@ -8212,18 +5650,12 @@
           "resolved": "https://registry.npmjs.org/is-data-descriptor/-/is-data-descriptor-0.1.4.tgz",
           "integrity": "sha1-C17mSDiOLIYCgueT8YVv7D8wG1Y=",
           "dev": true,
-          "requires": {
-            "kind-of": "3.2.2"
-          },
           "dependencies": {
             "kind-of": {
               "version": "3.2.2",
               "resolved": "https://registry.npmjs.org/kind-of/-/kind-of-3.2.2.tgz",
               "integrity": "sha1-MeohpzS6ubuw8yRm2JOupR5KPGQ=",
-              "dev": true,
-              "requires": {
-                "is-buffer": "1.1.6"
-              }
+              "dev": true
             }
           }
         },
@@ -8231,12 +5663,7 @@
           "version": "0.1.6",
           "resolved": "https://registry.npmjs.org/is-descriptor/-/is-descriptor-0.1.6.tgz",
           "integrity": "sha512-avDYr0SB3DwO9zsMov0gKCESFYqCnE4hq/4z3TdUlukEy5t9C0YRq7HLrsN52NAcqXKaepeCD0n+B0arnVG3Hg==",
-          "dev": true,
-          "requires": {
-            "is-accessor-descriptor": "0.1.6",
-            "is-data-descriptor": "0.1.4",
-            "kind-of": "5.1.0"
-          }
+          "dev": true
         },
         "isobject": {
           "version": "3.0.1",
@@ -8263,9 +5690,6 @@
       "resolved": "https://registry.npmjs.org/util/-/util-0.10.3.tgz",
       "integrity": "sha1-evsa/lCAUkZInj23/g7TeTNqwPk=",
       "dev": true,
-      "requires": {
-        "inherits": "2.0.1"
-      },
       "dependencies": {
         "inherits": {
           "version": "2.0.1",
@@ -8285,91 +5709,43 @@
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/v8flags/-/v8flags-2.1.1.tgz",
       "integrity": "sha1-qrGh+jDUX4jdMhFIh1rALAtV5bQ=",
-      "dev": true,
-      "requires": {
-        "user-home": "1.1.1"
-      }
+      "dev": true
     },
     "validate-npm-package-license": {
       "version": "3.0.1",
       "resolved": "https://registry.npmjs.org/validate-npm-package-license/-/validate-npm-package-license-3.0.1.tgz",
       "integrity": "sha1-KAS6vnEq0zeUWaz74kdGqywwP7w=",
-      "dev": true,
-      "requires": {
-        "spdx-correct": "1.0.2",
-        "spdx-expression-parse": "1.0.4"
-      }
+      "dev": true
     },
     "vm-browserify": {
       "version": "0.0.4",
       "resolved": "https://registry.npmjs.org/vm-browserify/-/vm-browserify-0.0.4.tgz",
       "integrity": "sha1-XX6kW7755Kb/ZflUOOCofDV9WnM=",
-      "dev": true,
-      "requires": {
-        "indexof": "0.0.1"
-      }
+      "dev": true
     },
     "walk-sync": {
       "version": "0.3.2",
       "resolved": "https://registry.npmjs.org/walk-sync/-/walk-sync-0.3.2.tgz",
       "integrity": "sha512-FMB5VqpLqOCcqrzA9okZFc0wq0Qbmdm396qJxvQZhDpyu0W95G9JCmp74tx7iyYnyOcBtUuKJsgIKAqjozvmmQ==",
-      "dev": true,
-      "requires": {
-        "ensure-posix-path": "1.0.2",
-        "matcher-collection": "1.0.5"
-      }
+      "dev": true
     },
     "watchpack": {
       "version": "1.4.0",
       "resolved": "https://registry.npmjs.org/watchpack/-/watchpack-1.4.0.tgz",
       "integrity": "sha1-ShRyvLuVK9Cpu0A2gB+VTfs5+qw=",
-      "dev": true,
-      "requires": {
-        "async": "2.6.0",
-        "chokidar": "1.7.0",
-        "graceful-fs": "4.1.11"
-      }
+      "dev": true
     },
     "webpack": {
       "version": "3.11.0",
       "resolved": "https://registry.npmjs.org/webpack/-/webpack-3.11.0.tgz",
       "integrity": "sha512-3kOFejWqj5ISpJk4Qj/V7w98h9Vl52wak3CLiw/cDOfbVTq7FeoZ0SdoHHY9PYlHr50ZS42OfvzE2vB4nncKQg==",
       "dev": true,
-      "requires": {
-        "acorn": "5.4.1",
-        "acorn-dynamic-import": "2.0.2",
-        "ajv": "6.1.1",
-        "ajv-keywords": "3.1.0",
-        "async": "2.6.0",
-        "enhanced-resolve": "3.4.1",
-        "escope": "3.6.0",
-        "interpret": "1.1.0",
-        "json-loader": "0.5.7",
-        "json5": "0.5.1",
-        "loader-runner": "2.3.0",
-        "loader-utils": "1.1.0",
-        "memory-fs": "0.4.1",
-        "mkdirp": "0.5.1",
-        "node-libs-browser": "2.1.0",
-        "source-map": "0.5.7",
-        "supports-color": "4.5.0",
-        "tapable": "0.2.8",
-        "uglifyjs-webpack-plugin": "0.4.6",
-        "watchpack": "1.4.0",
-        "webpack-sources": "1.1.0",
-        "yargs": "8.0.2"
-      },
       "dependencies": {
         "ajv": {
           "version": "6.1.1",
           "resolved": "https://registry.npmjs.org/ajv/-/ajv-6.1.1.tgz",
           "integrity": "sha1-l41Zf7wrfQ5aXD3esUmmgvKr+g4=",
-          "dev": true,
-          "requires": {
-            "fast-deep-equal": "1.0.0",
-            "fast-json-stable-stringify": "2.0.0",
-            "json-schema-traverse": "0.3.1"
-          }
+          "dev": true
         },
         "ajv-keywords": {
           "version": "3.1.0",
@@ -8387,10 +5763,7 @@
           "version": "4.5.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-4.5.0.tgz",
           "integrity": "sha1-vnoN5ITexcXN34s9WRJQRJEvY1s=",
-          "dev": true,
-          "requires": {
-            "has-flag": "2.0.0"
-          }
+          "dev": true
         }
       }
     },
@@ -8399,10 +5772,6 @@
       "resolved": "https://registry.npmjs.org/webpack-sources/-/webpack-sources-1.1.0.tgz",
       "integrity": "sha512-aqYp18kPphgoO5c/+NaUvEeACtZjMESmDChuD3NBciVpah3XpMEU9VAAtIaB1BsfJWWTSdv8Vv1m3T0aRk2dUw==",
       "dev": true,
-      "requires": {
-        "source-list-map": "2.0.0",
-        "source-map": "0.6.1"
-      },
       "dependencies": {
         "source-map": {
           "version": "0.6.1",
@@ -8416,11 +5785,7 @@
       "version": "0.7.0",
       "resolved": "https://registry.npmjs.org/websocket-driver/-/websocket-driver-0.7.0.tgz",
       "integrity": "sha1-DK+dLXVdk67gSdS90NP+LMoqJOs=",
-      "dev": true,
-      "requires": {
-        "http-parser-js": "0.4.12",
-        "websocket-extensions": "0.1.3"
-      }
+      "dev": true
     },
     "websocket-extensions": {
       "version": "0.1.3",
@@ -8438,10 +5803,7 @@
       "version": "1.3.0",
       "resolved": "https://registry.npmjs.org/which/-/which-1.3.0.tgz",
       "integrity": "sha512-xcJpopdamTuY5duC/KnTTNBraPK54YwpenP4lzxU8H91GudWpFv38u0CKjclE1Wi2EH2EDz5LRcHcKbCIzqGyg==",
-      "dev": true,
-      "requires": {
-        "isexe": "2.0.0"
-      }
+      "dev": true
     },
     "which-module": {
       "version": "2.0.0",
@@ -8453,10 +5815,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/widest-line/-/widest-line-2.0.0.tgz",
       "integrity": "sha1-AUKk6KJD+IgsAjOqDgKBqnYVInM=",
-      "dev": true,
-      "requires": {
-        "string-width": "2.1.1"
-      }
+      "dev": true
     },
     "window-size": {
       "version": "0.1.0",
@@ -8475,39 +5834,24 @@
       "resolved": "https://registry.npmjs.org/wrap-ansi/-/wrap-ansi-2.1.0.tgz",
       "integrity": "sha1-2Pw9KE3QV5T+hJc8rs3Rz4JP3YU=",
       "dev": true,
-      "requires": {
-        "string-width": "1.0.2",
-        "strip-ansi": "3.0.1"
-      },
       "dependencies": {
         "is-fullwidth-code-point": {
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "dev": true
         },
         "string-width": {
           "version": "1.0.2",
           "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
           "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-          "dev": true,
-          "requires": {
-            "code-point-at": "1.1.0",
-            "is-fullwidth-code-point": "1.0.0",
-            "strip-ansi": "3.0.1"
-          }
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+          "dev": true
         }
       }
     },
@@ -8521,21 +5865,13 @@
       "version": "0.2.1",
       "resolved": "https://registry.npmjs.org/write/-/write-0.2.1.tgz",
       "integrity": "sha1-X8A4KOJkzqP+kUVUdvejxWbLB1c=",
-      "dev": true,
-      "requires": {
-        "mkdirp": "0.5.1"
-      }
+      "dev": true
     },
     "write-file-atomic": {
       "version": "2.3.0",
       "resolved": "https://registry.npmjs.org/write-file-atomic/-/write-file-atomic-2.3.0.tgz",
       "integrity": "sha512-xuPeK4OdjWqtfi59ylvVL0Yn35SF3zgcAcv7rBPFHVaEapaDr4GdGgm3j7ckTwH9wHL7fGmgfAnb0+THrHb8tA==",
-      "dev": true,
-      "requires": {
-        "graceful-fs": "4.1.11",
-        "imurmurhash": "0.1.4",
-        "signal-exit": "3.0.2"
-      }
+      "dev": true
     },
     "xdg-basedir": {
       "version": "3.0.0",
@@ -8572,21 +5908,6 @@
       "resolved": "https://registry.npmjs.org/yargs/-/yargs-8.0.2.tgz",
       "integrity": "sha1-YpmpBVsc78lp/355wdkY3Osiw2A=",
       "dev": true,
-      "requires": {
-        "camelcase": "4.1.0",
-        "cliui": "3.2.0",
-        "decamelize": "1.2.0",
-        "get-caller-file": "1.0.2",
-        "os-locale": "2.1.0",
-        "read-pkg-up": "2.0.0",
-        "require-directory": "2.1.1",
-        "require-main-filename": "1.0.1",
-        "set-blocking": "2.0.0",
-        "string-width": "2.1.1",
-        "which-module": "2.0.0",
-        "y18n": "3.2.1",
-        "yargs-parser": "7.0.0"
-      },
       "dependencies": {
         "camelcase": {
           "version": "4.1.0",
@@ -8599,22 +5920,12 @@
           "resolved": "https://registry.npmjs.org/cliui/-/cliui-3.2.0.tgz",
           "integrity": "sha1-EgYBU3qRbSmUD5NNo7SNWFo5IT0=",
           "dev": true,
-          "requires": {
-            "string-width": "1.0.2",
-            "strip-ansi": "3.0.1",
-            "wrap-ansi": "2.1.0"
-          },
           "dependencies": {
             "string-width": {
               "version": "1.0.2",
               "resolved": "https://registry.npmjs.org/string-width/-/string-width-1.0.2.tgz",
               "integrity": "sha1-EYvfW4zcUaKn5w0hHgfisLmxB9M=",
-              "dev": true,
-              "requires": {
-                "code-point-at": "1.1.0",
-                "is-fullwidth-code-point": "1.0.0",
-                "strip-ansi": "3.0.1"
-              }
+              "dev": true
             }
           }
         },
@@ -8622,19 +5933,13 @@
           "version": "1.0.0",
           "resolved": "https://registry.npmjs.org/is-fullwidth-code-point/-/is-fullwidth-code-point-1.0.0.tgz",
           "integrity": "sha1-754xOG8DGn8NZDr4L95QxFfvAMs=",
-          "dev": true,
-          "requires": {
-            "number-is-nan": "1.0.1"
-          }
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
           "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
-          "dev": true,
-          "requires": {
-            "ansi-regex": "2.1.1"
-          }
+          "dev": true
         }
       }
     },
@@ -8643,9 +5948,6 @@
       "resolved": "https://registry.npmjs.org/yargs-parser/-/yargs-parser-7.0.0.tgz",
       "integrity": "sha1-jQrELxbqVd69MyyvTEA4s+P139k=",
       "dev": true,
-      "requires": {
-        "camelcase": "4.1.0"
-      },
       "dependencies": {
         "camelcase": {
           "version": "4.1.0",

--- a/package-lock.json
+++ b/package-lock.json
@@ -184,12 +184,14 @@
     "ansi-regex": {
       "version": "2.1.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-2.1.1.tgz",
-      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8="
+      "integrity": "sha1-w7M6te42DYbg5ijwRorn7yfWVN8=",
+      "dev": true
     },
     "ansi-styles": {
       "version": "2.2.1",
       "resolved": "https://registry.npmjs.org/ansi-styles/-/ansi-styles-2.2.1.tgz",
-      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4="
+      "integrity": "sha1-tDLdM1i2NM914eRmQ2gkBTPB3b4=",
+      "dev": true
     },
     "anymatch": {
       "version": "1.3.2",
@@ -321,21 +323,25 @@
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-code-frame/-/babel-code-frame-6.26.0.tgz",
       "integrity": "sha1-Y/1D99weO7fONZR9uP42mj9Yx0s=",
+      "dev": true,
       "dependencies": {
         "chalk": {
           "version": "1.1.3",
           "resolved": "https://registry.npmjs.org/chalk/-/chalk-1.1.3.tgz",
-          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg="
+          "integrity": "sha1-qBFcVeSnAv5NFQq9OHKCKn4J/Jg=",
+          "dev": true
         },
         "strip-ansi": {
           "version": "3.0.1",
           "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-3.0.1.tgz",
-          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8="
+          "integrity": "sha1-ajhfuIU9lS1f8F0Oiq+UJ43GPc8=",
+          "dev": true
         },
         "supports-color": {
           "version": "2.0.0",
           "resolved": "https://registry.npmjs.org/supports-color/-/supports-color-2.0.0.tgz",
-          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc="
+          "integrity": "sha1-U10EXOa2Nj+kARcIRimZXp3zJMc=",
+          "dev": true
         }
       }
     },
@@ -378,12 +384,14 @@
     "babel-helper-function-name": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-function-name/-/babel-helper-function-name-6.24.1.tgz",
-      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk="
+      "integrity": "sha1-00dbjAPtmCQqJbSDUasYOZ01gKk=",
+      "dev": true
     },
     "babel-helper-get-function-arity": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-get-function-arity/-/babel-helper-get-function-arity-6.24.1.tgz",
-      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0="
+      "integrity": "sha1-j3eCqpNAfEHTqlCQj4mwMbG2hT0=",
+      "dev": true
     },
     "babel-helper-hoist-variables": {
       "version": "6.24.1",
@@ -406,7 +414,8 @@
     "babel-helper-remap-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-helper-remap-async-to-generator/-/babel-helper-remap-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs="
+      "integrity": "sha1-XsWBgnrXI/7N04HxySg5BnbkVRs=",
+      "dev": true
     },
     "babel-helper-replace-supers": {
       "version": "6.24.1",
@@ -423,7 +432,8 @@
     "babel-messages": {
       "version": "6.23.0",
       "resolved": "https://registry.npmjs.org/babel-messages/-/babel-messages-6.23.0.tgz",
-      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4="
+      "integrity": "sha1-8830cDhYA1sqKVHG7F7fbGLyYw4=",
+      "dev": true
     },
     "babel-plugin-add-module-exports": {
       "version": "0.2.1",
@@ -440,7 +450,8 @@
     "babel-plugin-syntax-async-functions": {
       "version": "6.13.0",
       "resolved": "https://registry.npmjs.org/babel-plugin-syntax-async-functions/-/babel-plugin-syntax-async-functions-6.13.0.tgz",
-      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU="
+      "integrity": "sha1-ytnK0RkbWtY0vzCuCHI5HgZHvpU=",
+      "dev": true
     },
     "babel-plugin-syntax-exponentiation-operator": {
       "version": "6.13.0",
@@ -457,7 +468,8 @@
     "babel-plugin-transform-async-to-generator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-async-to-generator/-/babel-plugin-transform-async-to-generator-6.24.1.tgz",
-      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E="
+      "integrity": "sha1-ZTbjeK/2yx1VF6wOQOs+n8jQh2E=",
+      "dev": true
     },
     "babel-plugin-transform-es2015-arrow-functions": {
       "version": "6.22.0",
@@ -591,6 +603,12 @@
       "integrity": "sha1-04sS9C6nMj9yk4fxinxa4frrNek=",
       "dev": true
     },
+    "babel-plugin-transform-es2017-object-entries": {
+      "version": "0.0.4",
+      "resolved": "https://registry.npmjs.org/babel-plugin-transform-es2017-object-entries/-/babel-plugin-transform-es2017-object-entries-0.0.4.tgz",
+      "integrity": "sha1-xco3xE0G/vY1IOMFeJn9TKGFsgA=",
+      "dev": true
+    },
     "babel-plugin-transform-exponentiation-operator": {
       "version": "6.24.1",
       "resolved": "https://registry.npmjs.org/babel-plugin-transform-exponentiation-operator/-/babel-plugin-transform-exponentiation-operator-6.24.1.tgz",
@@ -638,34 +656,40 @@
     "babel-runtime": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-runtime/-/babel-runtime-6.26.0.tgz",
-      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4="
+      "integrity": "sha1-llxwWGaOgrVde/4E/yM3vItWR/4=",
+      "dev": true
     },
     "babel-template": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-template/-/babel-template-6.26.0.tgz",
-      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI="
+      "integrity": "sha1-3gPi0WOWsGn0bdn/+FIfsaDjXgI=",
+      "dev": true
     },
     "babel-traverse": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-traverse/-/babel-traverse-6.26.0.tgz",
       "integrity": "sha1-RqnL1+3MYsjlwGTi0tjQ9ANXZu4=",
+      "dev": true,
       "dependencies": {
         "globals": {
           "version": "9.18.0",
           "resolved": "https://registry.npmjs.org/globals/-/globals-9.18.0.tgz",
-          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ=="
+          "integrity": "sha512-S0nG3CLEQiY/ILxqtztTWH/3iRRdyBLw6KMDxnKMchrtbj2OFmehVh0WUCfW3DUrIgx/qFrJPICrq4Z4sTR9UQ==",
+          "dev": true
         }
       }
     },
     "babel-types": {
       "version": "6.26.0",
       "resolved": "https://registry.npmjs.org/babel-types/-/babel-types-6.26.0.tgz",
-      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc="
+      "integrity": "sha1-o7Bz+Uq0nrb6Vc1lInozQ4BjJJc=",
+      "dev": true
     },
     "babylon": {
       "version": "6.18.0",
       "resolved": "https://registry.npmjs.org/babylon/-/babylon-6.18.0.tgz",
-      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ=="
+      "integrity": "sha512-q/UEjfGJ2Cm3oKV71DJz9d25TPnq5rhBVL2Q4fA5wcC3jcrdn7+SssEybFIxwAvvP+YCsCYNKughoF33GxgycQ==",
+      "dev": true
     },
     "balanced-match": {
       "version": "1.0.0",
@@ -1122,7 +1146,8 @@
     "core-js": {
       "version": "2.5.5",
       "resolved": "https://registry.npmjs.org/core-js/-/core-js-2.5.5.tgz",
-      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs="
+      "integrity": "sha1-sU3ek2xkDAV5prUMq8wTLdYSfjs=",
+      "dev": true
     },
     "core-util-is": {
       "version": "1.0.2",
@@ -1193,7 +1218,8 @@
     "debug": {
       "version": "2.6.9",
       "resolved": "https://registry.npmjs.org/debug/-/debug-2.6.9.tgz",
-      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA=="
+      "integrity": "sha512-bC7ElrdJaJnPbAP+1EotYvqZsb3ecl5wi6Bfi6BJTUcNowp6cvspg0jXznRTKDjm/E7AdgFBVeAPVMNcKGsHMA==",
+      "dev": true
     },
     "decamelize": {
       "version": "1.2.0",
@@ -1436,7 +1462,8 @@
     "escape-string-regexp": {
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/escape-string-regexp/-/escape-string-regexp-1.0.5.tgz",
-      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ="
+      "integrity": "sha1-G2HAViGQqN/2rjuyzwIAyhMLhtQ=",
+      "dev": true
     },
     "escope": {
       "version": "3.6.0",
@@ -1547,7 +1574,8 @@
     "esutils": {
       "version": "2.0.2",
       "resolved": "https://registry.npmjs.org/esutils/-/esutils-2.0.2.tgz",
-      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs="
+      "integrity": "sha1-Cr9PHKpbyx96nYrMbepPqqBLrJs=",
+      "dev": true
     },
     "event-emitter": {
       "version": "0.3.5",
@@ -3204,7 +3232,8 @@
     "has-ansi": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/has-ansi/-/has-ansi-2.0.0.tgz",
-      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE="
+      "integrity": "sha1-NPUEnOHs3ysGSa8+8k5F7TVBbZE=",
+      "dev": true
     },
     "has-flag": {
       "version": "3.0.0",
@@ -3377,7 +3406,8 @@
     "invariant": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/invariant/-/invariant-2.2.4.tgz",
-      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA=="
+      "integrity": "sha512-phJfQVBuaJM5raOpJjSfkiD6BpbCE4Ns//LaXl6wGYtUBY83nWS6Rf9tXm2e8VaK60JEjYldbPif/A2B1C2gNA==",
+      "dev": true
     },
     "invert-kv": {
       "version": "1.0.0",
@@ -3680,7 +3710,8 @@
     "js-tokens": {
       "version": "3.0.2",
       "resolved": "https://registry.npmjs.org/js-tokens/-/js-tokens-3.0.2.tgz",
-      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls="
+      "integrity": "sha1-mGbfOVECEw449/mWvOtlRDIJwls=",
+      "dev": true
     },
     "js-yaml": {
       "version": "3.10.0",
@@ -3801,7 +3832,8 @@
     "lodash": {
       "version": "4.17.5",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.5.tgz",
-      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw=="
+      "integrity": "sha512-svL3uiZf1RwhH+cWrfZn3A4+U58wbP0tGVTLQPbjplZxZ8ROD9VLuNgsRniTlLe7OlSqR79RUehXgpBW/s0IQw==",
+      "dev": true
     },
     "lodash.cond": {
       "version": "4.5.2",
@@ -3836,7 +3868,8 @@
     "loose-envify": {
       "version": "1.3.1",
       "resolved": "https://registry.npmjs.org/loose-envify/-/loose-envify-1.3.1.tgz",
-      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg="
+      "integrity": "sha1-0aitM/qc4OcT1l/dCsi3SNR4yEg=",
+      "dev": true
     },
     "loud-rejection": {
       "version": "1.6.0",
@@ -4045,7 +4078,8 @@
     "ms": {
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/ms/-/ms-2.0.0.tgz",
-      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g="
+      "integrity": "sha1-VgiurfwAvmwpAd9fmGF4jeDVl8g=",
+      "dev": true
     },
     "mute-stream": {
       "version": "0.0.7",
@@ -4757,7 +4791,8 @@
     "regenerator-runtime": {
       "version": "0.11.1",
       "resolved": "https://registry.npmjs.org/regenerator-runtime/-/regenerator-runtime-0.11.1.tgz",
-      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg=="
+      "integrity": "sha512-MguG95oij0fC3QV3URf4V2SDYGJhJnJGqvIIgdECeODCT98wSWDAJ94SSuVpYQUoTcGUIL6L4yNB7j1DFFHSBg==",
+      "dev": true
     },
     "regenerator-transform": {
       "version": "0.10.1",
@@ -5382,7 +5417,8 @@
     "to-fast-properties": {
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/to-fast-properties/-/to-fast-properties-1.0.3.tgz",
-      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc="
+      "integrity": "sha1-uDVx+k2MJbguIxsG46MFXeTKGkc=",
+      "dev": true
     },
     "to-object-path": {
       "version": "0.3.0",

--- a/package.json
+++ b/package.json
@@ -22,6 +22,7 @@
   "devDependencies": {
     "babel-cli": "^6.26.0",
     "babel-plugin-add-module-exports": "^0.2.1",
+    "babel-plugin-transform-es2017-object-entries": "0.0.4",
     "babel-preset-env": "^1.7.0",
     "del-cli": "^1.1.0",
     "eslint": "^4.17.0",

--- a/src/firebase/firestore/document-snapshot/index.js
+++ b/src/firebase/firestore/document-snapshot/index.js
@@ -43,26 +43,42 @@ export default class DocumentSnapshot {
   }
 
   _getData() {
-    const data = Object.assign({}, this._data);
-
-    for (const key of Object.keys(data)) {
-      if (typeof data[key] === 'string' && data[key].startsWith('__ref__:')) {
-        data[key] = this._buildRefFromPath(this.ref.firestore, data[key].replace('__ref__:', ''));
-      } else if (data[key] instanceof Date) {
-        const date = data[key];
-
-        data[key] = {
-          toDate() {
-            return date;
-          },
-        };
-      }
-    }
+    const data = this._traverseObject(Object.assign({}, this._data));
 
     delete data.__isDirty__;
     delete data.__collection__;
 
     return data;
+  }
+
+  _traverseObject(o) {
+    if (typeof o === 'string') {
+      if (o.startsWith('__ref__:')) {
+        return this._buildRefFromPath(this.ref.firestore, o.replace('__ref__:', ''));
+      }
+      return o;
+    } else if (typeof o === 'object' && o !== null) {
+      if (o.constructor === Object) {
+        return Object.entries(o).reduce((accumulator, [key, value]) => {
+          if (key === '__collection__' || key === '__doc__') {
+            return Object.assign({}, accumulator, this._traverseObject.call(this, value));
+          } else {
+            return Object.assign({}, accumulator, {
+              [key]: this._traverseObject.call(this, value),
+            });
+          }
+        }, {});
+      } else if (o.constructor === Array) {
+        return o.map(this._traverseObject.bind(this));
+      } else if (o.constructor === Date) {
+        return {
+          toDate() {
+            return o;
+          },
+        };
+      }
+    }
+    return o;
   }
 
   _buildRefFromPath(db, path) {

--- a/src/unit-test.js
+++ b/src/unit-test.js
@@ -737,6 +737,20 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
         assert.equal(username, 'user_a');
       });
 
+      QUnit.test('should flatten nested data', async (assert) => {
+        assert.expect(2);
+        // Arrange
+        const db = mockFirebase.firestore();
+        const snapshot = await db.collection('users').doc('user_d').get();
+        const {
+          location,
+          family,
+        } = snapshot.data();
+
+        assert.deepEqual(location, { country: 'Australia', state: 'VIC' });
+        assert.ok(family.parent instanceof DocumentReference);
+      });
+
       QUnit.test('should return the data and match any reference type field appropriately', async (assert) => {
         assert.expect(3);
 
@@ -898,7 +912,7 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
         const result = snapshot.size;
 
         // Assert
-        assert.equal(result, 3);
+        assert.equal(result, 4);
       });
     });
 
@@ -915,7 +929,7 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
         snapshot.forEach(stub);
 
         // Assert
-        assert.ok(stub.calledThrice);
+        assert.equal(4, stub.callCount);
       });
     });
   });
@@ -1065,7 +1079,7 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
 
     QUnit.module('function: startAfter', () => {
       QUnit.test('should return documents satisfying the query', async (assert) => {
-        assert.expect(2);
+        assert.expect(3);
 
         // Arrange
         const db = mockFirebase.firestore();
@@ -1074,8 +1088,9 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
         const snapshot = await db.collection('users').orderBy('age').startAfter(15).get();
 
         // Assert
-        assert.equal(snapshot.docs.length, 1);
+        assert.equal(snapshot.docs.length, 2);
         assert.equal(snapshot.docs[0].id, 'user_c');
+        assert.equal(snapshot.docs[1].id, 'user_d');
       });
 
       QUnit.test('should error when not doing orderBy()', async (assert) => {
@@ -1096,7 +1111,7 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
 
     QUnit.module('function: startAt', () => {
       QUnit.test('should return documents satisfying the query', async (assert) => {
-        assert.expect(3);
+        assert.expect(4);
 
         // Arrange
         const db = mockFirebase.firestore();
@@ -1105,9 +1120,10 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
         const snapshot = await db.collection('users').orderBy('age').startAt(15).get();
 
         // Assert
-        assert.equal(snapshot.docs.length, 2);
+        assert.equal(snapshot.docs.length, 3);
         assert.equal(snapshot.docs[0].id, 'user_a');
         assert.equal(snapshot.docs[1].id, 'user_c');
+        assert.equal(snapshot.docs[2].id, 'user_d');
       });
 
       QUnit.test('should error when not doing orderBy()', async (assert) => {

--- a/src/utils/test-helpers/fixture-data.js
+++ b/src/utils/test-helpers/fixture-data.js
@@ -26,7 +26,6 @@ export default function fixtureData() {
             age: 10,
             createdOn: new Date('2017-01-01'),
             username: 'user_b',
-
             __collection__: {
               friends: {
                 __doc__: {
@@ -41,6 +40,29 @@ export default function fixtureData() {
             age: 20,
             createdOn: new Date('2017-01-01'),
             username: 'user_c',
+          },
+          user_d: {
+            age: 20,
+            createdOn: new Date('2017-01-01'),
+            username: 'user_b',
+            phone: [
+              {
+                number: '04123-2345',
+                type: 'mobile',
+              },
+            ],
+            family: {
+              parent: '__ref__:users/user_a',
+            },
+              __collection__: {
+                  location: {
+                      __doc__: {
+                          country: 'Australia',
+                          state: 'VIC',
+                      }
+                  }
+              }
+            ,
           },
         },
       },


### PR DESCRIPTION
## What?
Flattens data (removes `__collection__` and `__doc__`) when data is requested from `DocumentSnapshot` via `.data()` as well as looks for `__ref__:` in nested objects.

### Nested references.
Let's say we have data-structure like this in **FireStore**
```
artist: {
    'jfghw57efzjbsdft': {
        name: "Some Amazing Band"
        albums: [
            {
                type: 'LP',
                reference: DocumentReference('albums/ghaeo5tgzd57th')
            },
            {
                type: 'LP',
                reference: DocumentReference('albums/bq58tgzdlkvb48')
            }
        ]
    }
}
```
and then we have some code that looks like this:
```
database.collection('artist')
    .doc('jfghw57efzjbsdft')
    .get()
    .then(artist => {
        const data = artist.data();
        return Promise.all(data.albums.map(album => album.reference.get()))
    })
    .then(albums => {
        albums.forEach(album => console.log(album.data()))
    })
```
Now this is gonna work in production, even though we get the top-most data for the **Artist** and the work on the sub-objects.

If we wanna test our code, we would build _mock data_ that could look like this:
```
__collection__: {
    artist: {
        __doc__: {
            'jfghw57efzjbsdft': {
                name: "Some Amazing Band",
                albums: [
                    {
                        type: 'LP',
                        reference: '__ref__:albums/ghaeo5tgzd57th'
                    },
                    {
                        type: 'LP',
                        reference: __ref__:albums/bq58tgzdlkvb48'
                    }
                ]
            }        
        }
    }    
}
```
This is not going to work because `albums.$.reference` is not going to be a `DocumentReference` object, it's just gonna be the `__ref__:....` string.

The reason for it is that current code doesn't recursively go through the data-structure it is returning and makes sure that it has mocked out all `DocumentReferences` .

This PR goes through all the returned data and makes sure that all references have been converted.

### Flatten data-structure
Lets say I have mocked data-structure like this:
```
__collection__: {
    user: {
        __doc__: {
            '1': {
                name: "John",
                __collection__: {
                    address: {
                        __doc__: {
                            country: "Australia",
                            state: "VIC"
                        }
                    }                
                }
            }        
        }
    }    
}
```
If I have code that looks like this:
```
database.doc('user.1.address.country').get()
```
It will work, but if I later in my code need it like this:
```
database.collection('user).doc(1).get().
    then(doc => {
        const data = doc.data()
        return `${data.name} lives in ${data.address.country}, ${data.address.state}`
    })
```
that is not going to work because for example, `address` doesn't contain a **country** `key`, it contains a `__doc__` and so on.

When data is returned via `.data()` call, it needs to be put in the same state as **FireStore** would return it. This means removing `__collection__` and `__doc__` keys. To put it simply , flatten the structure.

This PR does that.


## How?

When `DocumentSnapshot` is asked to return its data:
1. Check value type (object, array, number, string...)
2. Recursively go through each key in the data object
3. For each sub-object value, create a shallow copy and  **go to step 2**
4. For each key that is `__collection__` or `__doc__`, hoist its values up (remove key) and **go to step 2**
5. For each string value, check if it starts with `__ref__:`, if so, create `DocumentReference`, else return
6. For each array, inspect and for each item **go to step 1**
7. For all other scalar types return.