### PR TITLE
Add support for new array APIs

### DIFF
--- a/dist/browser/mock-cloud-firestore.js
+++ b/dist/browser/mock-cloud-firestore.js
@@ -469,6 +469,8 @@ function where(data = {}, key, operator, value) {
       return pathValue === value;
     } else if (operator === '>=') {
       return pathValue >= value;
+    } else if (operator === 'array-contains') {
+      return pathValue.find(item => item === value);
     }
 
     return pathValue > value;
@@ -582,28 +584,14 @@ class DocumentReference {
 
   set(data, option = {}) {
     if (!option.merge) {
-      for (const key of Object.keys(this._data)) {
+      Object.keys(this._data).forEach(key => {
         if (key !== '__collection__') {
           delete this._data[key];
         }
-      }
+      });
     }
 
-    const parsedData = Object.assign({}, data);
-
-    for (const field of Object.keys(parsedData)) {
-      if (parsedData[field]) {
-        if (parsedData[field] instanceof DocumentReference) {
-          parsedData[field] = (0, _path.buildPathFromReference)(parsedData[field]);
-        }
-
-        if (typeof parsedData[field] === 'object' && Object.prototype.hasOwnProperty.call(parsedData[field], '_methodName') && parsedData[field]._methodName === 'FieldValue.serverTimestamp') {
-          parsedData[field] = new Date();
-        }
-      }
-    }
-
-    Object.assign(this._data, parsedData, { __isDirty__: false });
+    Object.assign(this._data, this._parseData(data), { __isDirty__: false });
 
     return Promise.resolve();
   }
@@ -613,21 +601,7 @@ class DocumentReference {
       throw new Error('Document doesn\'t exist');
     }
 
-    const parsedData = Object.assign({}, data);
-
-    for (const field of Object.keys(parsedData)) {
-      if (parsedData[field]) {
-        if (parsedData[field] instanceof DocumentReference) {
-          parsedData[field] = (0, _path.buildPathFromReference)(parsedData[field]);
-        }
-
-        if (typeof parsedData[field] === 'object' && Object.prototype.hasOwnProperty.call(parsedData[field], '_methodName') && parsedData[field]._methodName === 'FieldValue.serverTimestamp') {
-          parsedData[field] = new Date();
-        }
-      }
-    }
-
-    Object.assign(this._data, parsedData);
+    Object.assign(this._data, this._parseData(data));
 
     return Promise.resolve();
   }
@@ -656,6 +630,54 @@ class DocumentReference {
     (0, _reference2.default)(ref, 'collection');
 
     return ref;
+  }
+
+  _parseData(newData) {
+    const parsedData = Object.assign({}, newData);
+
+    Object.keys(parsedData).forEach(key => {
+      if (parsedData[key]) {
+        if (parsedData[key] instanceof DocumentReference) {
+          parsedData[key] = (0, _path.buildPathFromReference)(parsedData[key]);
+        }
+
+        if (typeof parsedData[key] === 'object' && Object.prototype.hasOwnProperty.call(parsedData[key], '_methodName')) {
+          const { _methodName: methodName } = parsedData[key];
+
+          if (methodName === 'FieldValue.serverTimestamp') {
+            parsedData[key] = new Date();
+          } else if (methodName === 'FieldValue.arrayUnion') {
+            parsedData[key] = this._processArrayUnion(key, parsedData[key]);
+          } else if (methodName === 'FieldValue.arrayRemove') {
+            parsedData[key] = this._processArrayRemove(key, parsedData[key]);
+          }
+        }
+      }
+    });
+
+    return parsedData;
+  }
+
+  _processArrayUnion(key, arrayUnion) {
+    const newArray = [...this._data[key]];
+
+    arrayUnion._elements.forEach(unionItem => {
+      if (!newArray.find(item => item === unionItem)) {
+        newArray.push(unionItem);
+      }
+    });
+
+    return newArray;
+  }
+
+  _processArrayRemove(key, arrayRemove) {
+    let newArray = [...this._data[key]];
+
+    arrayRemove._elements.forEach(unionItem => {
+      newArray = newArray.filter(item => item !== unionItem);
+    });
+
+    return newArray;
   }
 }
 exports.default = DocumentReference;
@@ -827,12 +849,26 @@ Object.defineProperty(exports, "__esModule", {
   value: true
 });
 class FieldValue {
+  arrayUnion(...args) {
+    return {
+      _methodName: 'FieldValue.arrayUnion',
+      _elements: [...args]
+    };
+  }
+
+  arrayRemove(...args) {
+    return {
+      _methodName: 'FieldValue.arrayRemove',
+      _elements: [...args]
+    };
+  }
+
   serverTimestamp() {
-    return new Date();
+    return { _methodName: 'FieldValue.serverTimestamp' };
   }
 }
 exports.default = FieldValue;
-module.exports = exports["default"];
+module.exports = exports['default'];
 
 /***/ }),
 /* 10 */

--- a/dist/node/firebase/firestore/field-value/index.js
+++ b/dist/node/firebase/firestore/field-value/index.js
@@ -1,12 +1,26 @@
-"use strict";
+'use strict';
 
 Object.defineProperty(exports, "__esModule", {
   value: true
 });
 class FieldValue {
+  arrayUnion(...args) {
+    return {
+      _methodName: 'FieldValue.arrayUnion',
+      _elements: [...args]
+    };
+  }
+
+  arrayRemove(...args) {
+    return {
+      _methodName: 'FieldValue.arrayRemove',
+      _elements: [...args]
+    };
+  }
+
   serverTimestamp() {
-    return new Date();
+    return { _methodName: 'FieldValue.serverTimestamp' };
   }
 }
 exports.default = FieldValue;
-module.exports = exports["default"];
+module.exports = exports['default'];

--- a/dist/node/unit-test.js
+++ b/dist/node/unit-test.js
@@ -650,7 +650,7 @@ QUnit.module('Unit | mock-cloud-firestore', hooks => {
                 QUnit.module('function: update', () => {
                         QUnit.test('should update the data', (() => {
                                 var _ref10 = _asyncToGenerator(function* (assert) {
-                                        assert.expect(7);
+                                        assert.expect(9);
 
                                         // Arrange
                                         const db = mockFirebase.firestore();
@@ -660,6 +660,8 @@ QUnit.module('Unit | mock-cloud-firestore', hooks => {
                                         yield ref.update({
                                                 dad: db.collection('users').doc('user_b'),
                                                 modifiedOn: _firebase2.default.firestore.FieldValue.serverTimestamp(),
+                                                pinnedBooks: _firebase2.default.firestore.FieldValue.arrayUnion('book_100'),
+                                                pinnedFoods: _firebase2.default.firestore.FieldValue.arrayRemove('food_1'),
                                                 name: 'user_a'
                                         });
 
@@ -672,6 +674,8 @@ QUnit.module('Unit | mock-cloud-firestore', hooks => {
                                                 dad,
                                                 modifiedOn,
                                                 name,
+                                                pinnedBooks,
+                                                pinnedFoods,
                                                 username
                                         } = snapshot.data();
 
@@ -681,6 +685,8 @@ QUnit.module('Unit | mock-cloud-firestore', hooks => {
                                         assert.deepEqual(dad, db.collection('users').doc('user_b'));
                                         assert.ok(modifiedOn.toDate() instanceof Date);
                                         assert.equal(name, 'user_a');
+                                        assert.deepEqual(pinnedBooks, ['book_1', 'book_2', 'book_100']);
+                                        assert.deepEqual(pinnedFoods, ['food_2']);
                                         assert.equal(username, 'user_a');
                                 });
 
@@ -964,15 +970,45 @@ QUnit.module('Unit | mock-cloud-firestore', hooks => {
         });
 
         QUnit.module('FieldValue', () => {
+                QUnit.module('function: arrayUnion', () => {
+                        QUnit.test('should return an array union representation', assert => {
+                                assert.expect(1);
+
+                                // Act
+                                const result = mockFirebase.firestore.FieldValue.arrayUnion('foo', 'bar');
+
+                                // Assert
+                                assert.deepEqual(result, {
+                                        _methodName: 'FieldValue.arrayUnion',
+                                        _elements: ['foo', 'bar']
+                                });
+                        });
+                });
+
+                QUnit.module('function: arrayRemove', () => {
+                        QUnit.test('should return an array union representation', assert => {
+                                assert.expect(1);
+
+                                // Act
+                                const result = mockFirebase.firestore.FieldValue.arrayRemove('foo', 'bar');
+
+                                // Assert
+                                assert.deepEqual(result, {
+                                        _methodName: 'FieldValue.arrayRemove',
+                                        _elements: ['foo', 'bar']
+                                });
+                        });
+                });
+
                 QUnit.module('function: serverTimestamp', () => {
-                        QUnit.test('should return a new date', assert => {
+                        QUnit.test('should return a server timestamp representation', assert => {
                                 assert.expect(1);
 
                                 // Act
                                 const result = mockFirebase.firestore.FieldValue.serverTimestamp();
 
                                 // Assert
-                                assert.ok(result instanceof Date);
+                                assert.deepEqual(result, { _methodName: 'FieldValue.serverTimestamp' });
                         });
                 });
         });

--- a/dist/node/utils/query/index.js
+++ b/dist/node/utils/query/index.js
@@ -148,6 +148,8 @@ function where(data = {}, key, operator, value) {
       return pathValue === value;
     } else if (operator === '>=') {
       return pathValue >= value;
+    } else if (operator === 'array-contains') {
+      return pathValue.find(item => item === value);
     }
 
     return pathValue > value;

--- a/dist/node/utils/query/unit-test.js
+++ b/dist/node/utils/query/unit-test.js
@@ -418,6 +418,26 @@ QUnit.module('Unit | Util | query', () => {
         user_c: { age: 20 }
       });
     });
+
+    QUnit.test('should return records matching the array-contains filter', assert => {
+      assert.expect(1);
+
+      // Arrange
+      const records = {
+        user_a: { books: [10] },
+        user_b: { books: [15] },
+        user_c: { books: [10] }
+      };
+
+      // Act
+      const result = (0, _.where)(records, 'books', 'array-contains', 10);
+
+      // Assert
+      assert.deepEqual(result, {
+        user_a: { books: [10] },
+        user_c: { books: [10] }
+      });
+    });
   });
 
   QUnit.module('function: querySnapshot', () => {

--- a/dist/node/utils/test-helpers/fixture-data.js
+++ b/dist/node/utils/test-helpers/fixture-data.js
@@ -16,6 +16,8 @@ function fixtureData() {
             },
             age: 15,
             createdOn: new Date('2017-01-01'),
+            pinnedBooks: ['book_1', 'book_2'],
+            pinnedFoods: ['food_1', 'food_2', 'food_1'],
             username: 'user_a',
 
             __collection__: {

--- a/src/firebase/firestore/document-reference/index.js
+++ b/src/firebase/firestore/document-reference/index.js
@@ -53,32 +53,14 @@ export default class DocumentReference {
 
   set(data, option = {}) {
     if (!option.merge) {
-      for (const key of Object.keys(this._data)) {
+      Object.keys(this._data).forEach((key) => {
         if (key !== '__collection__') {
           delete this._data[key];
         }
-      }
+      });
     }
 
-    const parsedData = Object.assign({}, data);
-
-    for (const field of Object.keys(parsedData)) {
-      if (parsedData[field]) {
-        if (parsedData[field] instanceof DocumentReference) {
-          parsedData[field] = buildPathFromReference(parsedData[field]);
-        }
-
-        if (
-          typeof parsedData[field] === 'object'
-          && Object.prototype.hasOwnProperty.call(parsedData[field], '_methodName')
-          && parsedData[field]._methodName === 'FieldValue.serverTimestamp'
-        ) {
-          parsedData[field] = new Date();
-        }
-      }
-    }
-
-    Object.assign(this._data, parsedData, { __isDirty__: false });
+    Object.assign(this._data, this._parseData(data), { __isDirty__: false });
 
     return Promise.resolve();
   }
@@ -88,25 +70,7 @@ export default class DocumentReference {
       throw new Error('Document doesn\'t exist');
     }
 
-    const parsedData = Object.assign({}, data);
-
-    for (const field of Object.keys(parsedData)) {
-      if (parsedData[field]) {
-        if (parsedData[field] instanceof DocumentReference) {
-          parsedData[field] = buildPathFromReference(parsedData[field]);
-        }
-
-        if (
-          typeof parsedData[field] === 'object'
-          && Object.prototype.hasOwnProperty.call(parsedData[field], '_methodName')
-          && parsedData[field]._methodName === 'FieldValue.serverTimestamp'
-        ) {
-          parsedData[field] = new Date();
-        }
-      }
-    }
-
-    Object.assign(this._data, parsedData);
+    Object.assign(this._data, this._parseData(data));
 
     return Promise.resolve();
   }
@@ -135,5 +99,56 @@ export default class DocumentReference {
     validateReference(ref, 'collection');
 
     return ref;
+  }
+
+  _parseData(newData) {
+    const parsedData = Object.assign({}, newData);
+
+    Object.keys(parsedData).forEach((key) => {
+      if (parsedData[key]) {
+        if (parsedData[key] instanceof DocumentReference) {
+          parsedData[key] = buildPathFromReference(parsedData[key]);
+        }
+
+        if (
+          typeof parsedData[key] === 'object'
+          && Object.prototype.hasOwnProperty.call(parsedData[key], '_methodName')
+        ) {
+          const { _methodName: methodName } = parsedData[key];
+
+          if (methodName === 'FieldValue.serverTimestamp') {
+            parsedData[key] = new Date();
+          } else if (methodName === 'FieldValue.arrayUnion') {
+            parsedData[key] = this._processArrayUnion(key, parsedData[key]);
+          } else if (methodName === 'FieldValue.arrayRemove') {
+            parsedData[key] = this._processArrayRemove(key, parsedData[key]);
+          }
+        }
+      }
+    });
+
+    return parsedData;
+  }
+
+  _processArrayUnion(key, arrayUnion) {
+    const newArray = [...this._data[key]];
+
+    arrayUnion._elements.forEach((unionItem) => {
+      if (!newArray.find(item => item === unionItem)) {
+        newArray.push(unionItem);
+      }
+    });
+
+    return newArray;
+  }
+
+  _processArrayRemove(key, arrayRemove) {
+    let newArray = [...this._data[key]];
+
+    arrayRemove._elements.forEach((unionItem) => {
+      newArray = newArray.filter(item => item !== unionItem);
+    });
+
+    return newArray;
   }
 }

--- a/src/firebase/firestore/field-value/index.js
+++ b/src/firebase/firestore/field-value/index.js
@@ -1,5 +1,19 @@
 export default class FieldValue {
+  arrayUnion(...args) {
+    return {
+      _methodName: 'FieldValue.arrayUnion',
+      _elements: [...args],
+    };
+  }
+
+  arrayRemove(...args) {
+    return {
+      _methodName: 'FieldValue.arrayRemove',
+      _elements: [...args],
+    };
+  }
+
   serverTimestamp() {
-    return new Date();
+    return { _methodName: 'FieldValue.serverTimestamp' };
   }
 }

--- a/src/unit-test.js
+++ b/src/unit-test.js
@@ -561,7 +561,7 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
 
     QUnit.module('function: update', () => {
       QUnit.test('should update the data', async (assert) => {
-        assert.expect(7);
+        assert.expect(9);
 
         // Arrange
         const db = mockFirebase.firestore();
@@ -571,6 +571,8 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
         await ref.update({
           dad: db.collection('users').doc('user_b'),
           modifiedOn: firebase.firestore.FieldValue.serverTimestamp(),
+          pinnedBooks: firebase.firestore.FieldValue.arrayUnion('book_100'),
+          pinnedFoods: firebase.firestore.FieldValue.arrayRemove('food_1'),
           name: 'user_a',
         });
 
@@ -583,6 +585,8 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
           dad,
           modifiedOn,
           name,
+          pinnedBooks,
+          pinnedFoods,
           username,
         } = snapshot.data();
 
@@ -592,6 +596,8 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
         assert.deepEqual(dad, db.collection('users').doc('user_b'));
         assert.ok(modifiedOn.toDate() instanceof Date);
         assert.equal(name, 'user_a');
+        assert.deepEqual(pinnedBooks, ['book_1', 'book_2', 'book_100']);
+        assert.deepEqual(pinnedFoods, ['food_2']);
         assert.equal(username, 'user_a');
       });
 
@@ -808,15 +814,45 @@ QUnit.module('Unit | mock-cloud-firestore', (hooks) => {
   });
 
   QUnit.module('FieldValue', () => {
+    QUnit.module('function: arrayUnion', () => {
+      QUnit.test('should return an array union representation', (assert) => {
+        assert.expect(1);
+
+        // Act
+        const result = mockFirebase.firestore.FieldValue.arrayUnion('foo', 'bar');
+
+        // Assert
+        assert.deepEqual(result, {
+          _methodName: 'FieldValue.arrayUnion',
+          _elements: ['foo', 'bar'],
+        });
+      });
+    });
+
+    QUnit.module('function: arrayRemove', () => {
+      QUnit.test('should return an array union representation', (assert) => {
+        assert.expect(1);
+
+        // Act
+        const result = mockFirebase.firestore.FieldValue.arrayRemove('foo', 'bar');
+
+        // Assert
+        assert.deepEqual(result, {
+          _methodName: 'FieldValue.arrayRemove',
+          _elements: ['foo', 'bar'],
+        });
+      });
+    });
+
     QUnit.module('function: serverTimestamp', () => {
-      QUnit.test('should return a new date', (assert) => {
+      QUnit.test('should return a server timestamp representation', (assert) => {
         assert.expect(1);
 
         // Act
         const result = mockFirebase.firestore.FieldValue.serverTimestamp();
 
         // Assert
-        assert.ok(result instanceof Date);
+        assert.deepEqual(result, { _methodName: 'FieldValue.serverTimestamp' });
       });
     });
   });

--- a/src/utils/query/index.js
+++ b/src/utils/query/index.js
@@ -127,6 +127,8 @@ export function where(data = {}, key, operator, value) {
       return pathValue === value;
     } else if (operator === '>=') {
       return pathValue >= value;
+    } else if (operator === 'array-contains') {
+      return pathValue.find(item => item === value);
     }
 
     return pathValue > value;

--- a/src/utils/query/unit-test.js
+++ b/src/utils/query/unit-test.js
@@ -425,6 +425,26 @@ QUnit.module('Unit | Util | query', () => {
         user_c: { age: 20 },
       });
     });
+
+    QUnit.test('should return records matching the array-contains filter', (assert) => {
+      assert.expect(1);
+
+      // Arrange
+      const records = {
+        user_a: { books: [10] },
+        user_b: { books: [15] },
+        user_c: { books: [10] },
+      };
+
+      // Act
+      const result = where(records, 'books', 'array-contains', 10);
+
+      // Assert
+      assert.deepEqual(result, {
+        user_a: { books: [10] },
+        user_c: { books: [10] },
+      });
+    });
   });
 
   QUnit.module('function: querySnapshot', () => {

--- a/src/utils/test-helpers/fixture-data.js
+++ b/src/utils/test-helpers/fixture-data.js
@@ -10,6 +10,8 @@ export default function fixtureData() {
             },
             age: 15,
             createdOn: new Date('2017-01-01'),
+            pinnedBooks: ['book_1', 'book_2'],
+            pinnedFoods: ['food_1', 'food_2', 'food_1'],
             username: 'user_a',
 
             __collection__: {


### PR DESCRIPTION
Support for:
- `array-contains` query
- `firebase.firestore.FieldValue.arrayUnion()`
- `firebase.firestore.FieldValue.arrayRemove()`